### PR TITLE
fix: update&fix example config blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ public:
       url: <<PLUGIN_URL>>
         dataChannels:
         - name: pickRandomUser
-          writePermission: ['presenter']
-          deletePermission: ['moderator', 'sender']
+          pushPermission: ['presenter']
+          replaceOrdeletePermission: ['moderator', 'creator']
         - name: modalInformationFromPresenter
           writePermission: ['presenter']
-          deletePermission: ['moderator', 'sender']
+          replaceOrdeletePermission: ['moderator', 'creator']
   ... // All other configurations
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ npm start
       dataChannels:
         - name: pickRandomUser
           pushPermission: ['presenter']
-          replaceOrdeletePermission: ['moderator', 'creator']
+          replaceOrDeletePermission: ['presenter']
         - name: modalInformationFromPresenter
-          writePermission: ['presenter']
-          replaceOrdeletePermission: ['moderator', 'creator']
+          pushPermission: ['presenter']
+          replaceOrDeletePermission: ['presenter']
 ```
 
 ## Building the Plugin
@@ -55,10 +55,10 @@ public:
         dataChannels:
         - name: pickRandomUser
           pushPermission: ['presenter']
-          replaceOrdeletePermission: ['moderator', 'creator']
+          replaceOrDeletePermission: ['presenter']
         - name: modalInformationFromPresenter
-          writePermission: ['presenter']
-          replaceOrdeletePermission: ['moderator', 'creator']
+          pushPermission: ['presenter']
+          replaceOrDeletePermission: ['presenter']
   ... // All other configurations
 ```
 


### PR DESCRIPTION
1) PR https://github.com/bigbluebutton/plugin-pick-random-user/pull/11 has updated the first example config block, but missed the second one.

2) Actually both config blocks had wrong permissions names (`replaceOrdeletePermission` instead of `replaceOrDeletePermission`) and (in my opinion) unnecessary or wrong scopes (`moderator`,  `creator` instead of `sender`).
Fixes https://github.com/bigbluebutton/plugin-pick-random-user/issues/20