### PR TITLE
fix: fix problem when new user comes in, modal pops up

### DIFF
--- a/src/components/extensible-areas/action-button-dropdown/component.tsx
+++ b/src/components/extensible-areas/action-button-dropdown/component.tsx
@@ -6,7 +6,7 @@ import { ActionButtonDropdownManagerProps } from './types';
 
 function ActionButtonDropdownManager(props: ActionButtonDropdownManagerProps): React.ReactNode {
   const {
-    pickedUser,
+    pickedUserWithEntryId,
     currentUser,
     pluginApi,
     setShowModal,
@@ -27,7 +27,7 @@ function ActionButtonDropdownManager(props: ActionButtonDropdownManagerProps): R
           },
         }),
       ]);
-    } else if (!currentUser?.presenter && pickedUser) {
+    } else if (!currentUser?.presenter && pickedUserWithEntryId) {
       pluginApi.setActionButtonDropdownItems([
         new ActionButtonDropdownSeparator(),
         new ActionButtonDropdownOption({
@@ -43,7 +43,7 @@ function ActionButtonDropdownManager(props: ActionButtonDropdownManagerProps): R
     } else {
       pluginApi.setActionButtonDropdownItems([]);
     }
-  }, [currentUserInfo, pickedUser]);
+  }, [currentUserInfo, pickedUserWithEntryId]);
   return null;
 }
 

--- a/src/components/extensible-areas/action-button-dropdown/types.ts
+++ b/src/components/extensible-areas/action-button-dropdown/types.ts
@@ -1,8 +1,8 @@
 import { CurrentUserData, GraphqlResponseWrapper, PluginApi } from 'bigbluebutton-html-plugin-sdk';
-import { PickedUser } from '../../pick-random-user/types';
+import { PickedUserWithEntryId } from '../../pick-random-user/types';
 
 export interface ActionButtonDropdownManagerProps {
-    pickedUser: PickedUser;
+    pickedUserWithEntryId: PickedUserWithEntryId;
     currentUser: CurrentUserData;
     pluginApi: PluginApi;
     setShowModal: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -11,7 +11,8 @@ export function PickUserModal(props: PickUserModalProps) {
     showModal,
     handleCloseModal,
     users,
-    pickedUser,
+    updatePickedRandomUser,
+    pickedUserWithEntryId,
     handlePickRandomUser,
     currentUser,
     filterOutPresenter,
@@ -29,16 +30,16 @@ export function PickUserModal(props: PickUserModalProps) {
   } else {
     userRole = (users?.length !== 1) ? 'users' : 'user';
   }
-  const title = (pickedUser?.userId === currentUser?.userId)
+  const title = (pickedUserWithEntryId?.pickedUser?.userId === currentUser?.userId)
     ? 'You have been randomly picked'
     : 'Randomly picked user';
 
   const [showPresenterView, setShowPresenterView] = useState<boolean>(
-    currentUser?.presenter && !pickedUser,
+    currentUser?.presenter && !pickedUserWithEntryId,
   );
   useEffect(() => {
-    setShowPresenterView(currentUser?.presenter && !pickedUser);
-  }, [currentUser, pickedUser]);
+    setShowPresenterView(currentUser?.presenter && !pickedUserWithEntryId);
+  }, [currentUser, pickedUserWithEntryId]);
   return (
     <ReactModal
       className="plugin-modal"
@@ -57,6 +58,7 @@ export function PickUserModal(props: PickUserModalProps) {
           onClick={() => {
             handleCloseModal();
           }}
+          aria-label="Close button"
         >
           <i
             className="icon-bbb-close"
@@ -75,7 +77,7 @@ export function PickUserModal(props: PickUserModalProps) {
                 deletionFunction,
                 handlePickRandomUser,
                 dataChannelPickedUsers,
-                pickedUser,
+                pickedUserWithEntryId,
                 users,
                 userRole,
                 dispatcherPickedUser,
@@ -84,8 +86,9 @@ export function PickUserModal(props: PickUserModalProps) {
           ) : (
             <PickedUserViewComponent
               {...{
-                pickedUser,
+                pickedUserWithEntryId,
                 title,
+                updatePickedRandomUser,
                 currentUser,
                 setShowPresenterView,
                 dispatcherPickedUser,

--- a/src/components/modal/picked-user-view/component.tsx
+++ b/src/components/modal/picked-user-view/component.tsx
@@ -4,11 +4,29 @@ import { PickedUserViewComponentProps } from './types';
 export function PickedUserViewComponent(props: PickedUserViewComponentProps) {
   const {
     title,
-    pickedUser,
+    pickedUserWithEntryId,
     currentUser,
+    updatePickedRandomUser,
     setShowPresenterView,
     dispatcherPickedUser,
   } = props;
+
+  React.useEffect(() => {
+    if (currentUser?.presenter) {
+      updatePickedRandomUser(pickedUserWithEntryId.entryId, {
+        ...pickedUserWithEntryId.pickedUser,
+        isPresenterViewing: true,
+      });
+    }
+    return () => {
+      if (currentUser?.presenter) {
+        updatePickedRandomUser(pickedUserWithEntryId.entryId, {
+          ...pickedUserWithEntryId.pickedUser,
+          isPresenterViewing: false,
+        });
+      }
+    };
+  }, []);
 
   const handleBackToPresenterView = () => {
     if (currentUser?.presenter) {
@@ -24,15 +42,15 @@ export function PickedUserViewComponent(props: PickedUserViewComponentProps) {
     >
       <h1 className="title">{title}</h1>
       {
-        (pickedUser) ? (
+        (pickedUserWithEntryId) ? (
           <>
             <div
               className="modal-avatar"
-              style={{ backgroundColor: `${pickedUser?.color}` }}
+              style={{ backgroundColor: `${pickedUserWithEntryId.pickedUser?.color}` }}
             >
-              {pickedUser?.name.slice(0, 2)}
+              {pickedUserWithEntryId.pickedUser?.name.slice(0, 2)}
             </div>
-            <p className="user-name">{pickedUser?.name}</p>
+            <p className="user-name">{pickedUserWithEntryId.pickedUser?.name}</p>
           </>
         ) : null
       }

--- a/src/components/modal/picked-user-view/types.ts
+++ b/src/components/modal/picked-user-view/types.ts
@@ -1,10 +1,11 @@
 import { CurrentUserData } from 'bigbluebutton-html-plugin-sdk';
-import { PushEntryFunction } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-channel/types';
-import { PickedUser } from '../../pick-random-user/types';
+import { PushEntryFunction, ReplaceEntryFunction } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-channel/types';
+import { PickedUser, PickedUserWithEntryId } from '../../pick-random-user/types';
 
 export interface PickedUserViewComponentProps {
     title: string;
-    pickedUser: PickedUser;
+    updatePickedRandomUser: ReplaceEntryFunction<PickedUser>;
+    pickedUserWithEntryId: PickedUserWithEntryId;
     currentUser: CurrentUserData;
     setShowPresenterView: React.Dispatch<React.SetStateAction<boolean>>;
     dispatcherPickedUser: PushEntryFunction

--- a/src/components/modal/presenter-view/component.tsx
+++ b/src/components/modal/presenter-view/component.tsx
@@ -43,7 +43,7 @@ export function PresenterViewComponent(props: PresenterViewComponentProps) {
     deletionFunction,
     handlePickRandomUser,
     dataChannelPickedUsers,
-    pickedUser,
+    pickedUserWithEntryId,
     users,
     userRole,
   } = props;
@@ -125,7 +125,7 @@ export function PresenterViewComponent(props: PresenterViewComponentProps) {
             }}
           >
             {
-            (pickedUser) ? 'Pick again' : `Pick ${userRole}`
+            (pickedUserWithEntryId) ? 'Pick again' : `Pick ${userRole}`
             }
           </button>
         ) : (

--- a/src/components/modal/presenter-view/types.ts
+++ b/src/components/modal/presenter-view/types.ts
@@ -1,6 +1,6 @@
 import { DataChannelEntryResponseType } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-channel/types';
 import { DeleteEntryFunction } from 'bigbluebutton-html-plugin-sdk';
-import { PickedUser } from '../../pick-random-user/types';
+import { PickedUser, PickedUserWithEntryId } from '../../pick-random-user/types';
 
 export interface PresenterViewComponentProps {
     filterOutPresenter: boolean;
@@ -10,7 +10,7 @@ export interface PresenterViewComponentProps {
     deletionFunction: DeleteEntryFunction;
     handlePickRandomUser: () => void;
     dataChannelPickedUsers?: DataChannelEntryResponseType<PickedUser>[];
-    pickedUser: PickedUser;
+    pickedUserWithEntryId: PickedUserWithEntryId;
     users?: PickedUser[];
     userRole: string;
 }

--- a/src/components/modal/types.ts
+++ b/src/components/modal/types.ts
@@ -1,12 +1,13 @@
 import { CurrentUserData, DeleteEntryFunction } from 'bigbluebutton-html-plugin-sdk';
-import { DataChannelEntryResponseType, PushEntryFunction } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-channel/types';
-import { PickedUser } from '../pick-random-user/types';
+import { DataChannelEntryResponseType, PushEntryFunction, ReplaceEntryFunction } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-channel/types';
+import { PickedUser, PickedUserWithEntryId } from '../pick-random-user/types';
 
 export interface PickUserModalProps {
   showModal: boolean;
+  updatePickedRandomUser: ReplaceEntryFunction<PickedUser>;
   handleCloseModal: () => void;
   users?: PickedUser[];
-  pickedUser: PickedUser;
+  pickedUserWithEntryId: PickedUserWithEntryId;
   handlePickRandomUser: () => void;
   currentUser: CurrentUserData;
   filterOutPresenter: boolean,

--- a/src/components/pick-random-user/component.tsx
+++ b/src/components/pick-random-user/component.tsx
@@ -6,6 +6,7 @@ import {
   ModalInformationFromPresenter,
   PickRandomUserPluginProps,
   PickedUser,
+  PickedUserWithEntryId,
   UsersMoreInformationGraphqlResponse,
 } from './types';
 import { USERS_MORE_INFORMATION } from './queries';
@@ -16,7 +17,9 @@ import ActionButtonDropdownManager from '../extensible-areas/action-button-dropd
 function PickRandomUserPlugin({ pluginUuid: uuid }: PickRandomUserPluginProps) {
   BbbPluginSdk.initialize(uuid);
   const [showModal, setShowModal] = useState<boolean>(false);
-  const [pickedUser, setPickedUser] = useState<PickedUser | undefined>();
+  const [
+    pickedUserWithEntryId,
+    setPickedUserWithEntryId] = useState<PickedUserWithEntryId | undefined>();
   const [userFilterViewer, setUserFilterViewer] = useState<boolean>(true);
   const [filterOutPresenter, setFilterOutPresenter] = useState<boolean>(true);
   const pluginApi: PluginApi = BbbPluginSdk.getPluginApi(uuid);
@@ -29,6 +32,7 @@ function PickRandomUserPlugin({ pluginUuid: uuid }: PickRandomUserPluginProps) {
   const {
     data: pickedUserFromDataChannelResponse,
     pushEntry: pushPickedUser,
+    replaceEntry: updatePickedRandomUser,
     deleteEntry: deletePickedUser,
   } = pluginApi.useDataChannel<PickedUser>('pickRandomUser');
   const {
@@ -94,18 +98,25 @@ function PickRandomUserPlugin({ pluginUuid: uuid }: PickRandomUserPluginProps) {
       && pickedUserFromDataChannel.data?.length > 0) {
       const pickedUserToUpdate = pickedUserFromDataChannel
         .data[0];
-      setPickedUser(pickedUserToUpdate?.payloadJson);
-      if (pickedUserToUpdate?.payloadJson) setShowModal(true);
+      if (pickedUserToUpdate?.entryId !== pickedUserWithEntryId?.entryId) {
+        setPickedUserWithEntryId({
+          pickedUser: pickedUserToUpdate?.payloadJson,
+          entryId: pickedUserToUpdate.entryId,
+        });
+      }
+      if (pickedUserToUpdate?.payloadJson && pickedUserToUpdate?.payloadJson.isPresenterViewing) {
+        setShowModal(true);
+      }
     } else if (pickedUserFromDataChannel.data
         && pickedUserFromDataChannel.data?.length === 0) {
-      setPickedUser(null);
+      setPickedUserWithEntryId(null);
       if (currentUser && !currentUser.presenter) setShowModal(false);
     }
   }, [pickedUserFromDataChannelResponse]);
 
   useEffect(() => {
-    if (!pickedUser && !currentUser?.presenter) setShowModal(false);
-  }, [pickedUser]);
+    if (!pickedUserWithEntryId && !currentUser?.presenter) setShowModal(false);
+  }, [pickedUserWithEntryId]);
 
   useEffect(() => {
     if (!currentUser?.presenter && dispatchModalInformationFromPresenter) handleCloseModal();
@@ -117,7 +128,7 @@ function PickRandomUserPlugin({ pluginUuid: uuid }: PickRandomUserPluginProps) {
           showModal,
           handleCloseModal,
           users: usersToBePicked?.user,
-          pickedUser,
+          pickedUserWithEntryId,
           handlePickRandomUser,
           currentUser,
           filterOutPresenter,
@@ -125,13 +136,14 @@ function PickRandomUserPlugin({ pluginUuid: uuid }: PickRandomUserPluginProps) {
           userFilterViewer,
           setUserFilterViewer,
           dataChannelPickedUsers: pickedUserFromDataChannel.data,
+          updatePickedRandomUser,
           dispatcherPickedUser: pushPickedUser,
           deletionFunction: deletePickedUser,
         }}
       />
       <ActionButtonDropdownManager
         {...{
-          pickedUser,
+          pickedUserWithEntryId,
           currentUser,
           pluginApi,
           setShowModal,

--- a/src/components/pick-random-user/types.ts
+++ b/src/components/pick-random-user/types.ts
@@ -1,9 +1,15 @@
 export interface PickedUser {
+    isPresenterViewing: boolean;
     presenter: boolean;
     userId: string;
     name: string;
     role: string;
     color: string;
+}
+
+export interface PickedUserWithEntryId {
+    pickedUser: PickedUser;
+    entryId: string;
 }
 
 export interface PickRandomUserPluginProps {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,11 +8,9 @@ const pluginName = document.currentScript?.getAttribute('pluginName') || 'plugin
 
 const root = ReactDOM.createRoot(document.getElementById(uuid));
 root.render(
-  <React.StrictMode>
-    <PickRandomUserPlugin {...{
-      pluginUuid: uuid,
-      pluginName,
-    }}
-    />
-  </React.StrictMode>,
+  <PickRandomUserPlugin {...{
+    pluginUuid: uuid,
+    pluginName,
+  }}
+  />,
 );


### PR DESCRIPTION
### What does this PR do?

Fixed issue when new user comes into the meeting, a modal showing the picked random user pops out to them.

New behaviour (following other features in BBB where the UI of the viewer should look like the presenter's):

- The presenter picks a random user;
- If the presenter still viewing the picked user, any new student that comes in, modal will pop out, so they see the same as the presenter (mind that there is the possibility for this user to close the modal);
- If the presenter has picked the user, but simply followed along with the class and now there is no modal to the presenter, any new student that comes in will not see the modal popping in.

Those are the premises I used for building this up, comment down below any suggestions you might have and let's discuss. 

### Closes Issue(s)

Closes #10

### More

See a demo of the last case scenario mentioned here in this PR (presenter closed the modal already):



https://github.com/user-attachments/assets/fab93169-d64b-486d-a3b5-5025a3dc090a


