### PR TITLE
feat: Add ping sound and notification for whenever the user is randomly picked

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,47 @@ The Pick Random User Plugin shows a modal for moderator to pick a user (mainly v
 
 ![Gif of plugin demo](./public/assets/plugin.gif)
 
+## Necessary configurations
+
+By default, no ping is sounded for the randomly picked user. To activate this feature, one must add the following configurations in their `/etc/bigbluebutton/bbb-html5.yml` file.
+
+So within that file and in `public.plugins` add the following configurations:
+
+```yaml
+- name: PickRandomUserPlugin
+      settings:
+        pingSoundEnabled: true
+        pingSoundUrl: resources/sounds/doorbell.mp3
+```
+
+The result yaml will look like:
+
+```yaml
+public:
+  # ...
+  plugins:
+    - name: PickRandomUserPlugin 
+      settings:
+        pingSoundEnabled: true # Enables the ping sound for this plugin true/false
+        pingSoundUrl: resources/sounds/doorbell.mp3 # This is the default and is not mandatory
+```
+
+Some other possible `pingSoundUrl` are (URL can be relative, if the `mp3` sound is being served from within the BBB server as showed right below):
+- resources/sounds/alarm.mp3  
+- resources/sounds/bbb-handRaise.mp3  
+- resources/sounds/LeftCall.mp3  
+- resources/sounds/RelaxingMusic.mp3  
+- resources/sounds/aristocratDrums.mp3  
+- resources/sounds/CalmMusic.mp3  
+- resources/sounds/notify.mp3  
+- resources/sounds/ScreenshareOff.mp3  
+- resources/sounds/audioSample.mp3  
+- resources/sounds/doorbell.mp3  
+- resources/sounds/Poll.mp3  
+- resources/sounds/userJoin.mp3
+
+These are the possible `mp3` that already come within a BBB server, if you want a custom sound, just add the URL to the `mp3` file there and it will work out of the box.
+
 ## Building the Plugin
 
 To build the plugin for production use, follow these steps:

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -61,10 +61,10 @@ export function PickUserModal(props: PickUserModalProps) {
     setShowPresenterView(currentUser?.presenter && !pickedUserWithEntryId);
     // Play audio when user is selected
     const isPingSoundEnabled = !isPluginSettingsLoading && pluginSettings?.pingSoundEnabled;
-    const pingSoundPath: string = pluginSettings?.pingSoundPath ? String(pluginSettings?.pingSoundPath) : 'resources/sounds/doorbell.mp3';
+    const pingSoundUrl: string = pluginSettings?.pingSoundUrl ? String(pluginSettings?.pingSoundUrl) : 'resources/sounds/doorbell.mp3';
     if (isPingSoundEnabled && pickedUserWithEntryId
       && pickedUserWithEntryId?.pickedUser?.userId === currentUser?.userId) {
-      const audio = new Audio(pingSoundPath);
+      const audio = new Audio(pingSoundUrl);
       audio.play();
       notifyRandomlyPickedUser(title);
     }

--- a/src/components/modal/presenter-view/component.tsx
+++ b/src/components/modal/presenter-view/component.tsx
@@ -21,8 +21,9 @@ const makeVerticalListOfNames = (
   list?: DataChannelEntryResponseType<PickedUser>[],
 ) => list?.filter((u) => !!u.payloadJson).map((u) => {
   const time = new Date(u.createdAt);
+  const timeMiliseconds = time.getTime();
   return (
-    <li key={u.payloadJson.userId}>
+    <li key={`${u.payloadJson.userId}-${timeMiliseconds}`}>
       {u.payloadJson.name}
       {' '}
       (

--- a/src/components/modal/types.ts
+++ b/src/components/modal/types.ts
@@ -1,8 +1,11 @@
+import { PluginSettingsData } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-consumption/domain/settings/plugin-settings/types';
 import { CurrentUserData, DeleteEntryFunction } from 'bigbluebutton-html-plugin-sdk';
 import { DataChannelEntryResponseType, PushEntryFunction, ReplaceEntryFunction } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-channel/types';
 import { PickedUser, PickedUserWithEntryId } from '../pick-random-user/types';
 
 export interface PickUserModalProps {
+  pluginSettings: PluginSettingsData;
+  isPluginSettingsLoading: boolean;
   showModal: boolean;
   updatePickedRandomUser: ReplaceEntryFunction<PickedUser>;
   handleCloseModal: () => void;

--- a/src/components/pick-random-user/component.tsx
+++ b/src/components/pick-random-user/component.tsx
@@ -16,6 +16,8 @@ import ActionButtonDropdownManager from '../extensible-areas/action-button-dropd
 
 function PickRandomUserPlugin({ pluginUuid: uuid }: PickRandomUserPluginProps) {
   BbbPluginSdk.initialize(uuid);
+  const pluginApi: PluginApi = BbbPluginSdk.getPluginApi(uuid);
+
   const [showModal, setShowModal] = useState<boolean>(false);
   const [
     pickedUserWithEntryId,
@@ -23,7 +25,17 @@ function PickRandomUserPlugin({ pluginUuid: uuid }: PickRandomUserPluginProps) {
   const [userFilterViewer, setUserFilterViewer] = useState<boolean>(true);
   const [filterOutPresenter, setFilterOutPresenter] = useState<boolean>(true);
   const [filterOutPickedUsers, setFilterOutPickedUsers] = useState<boolean>(true);
-  const pluginApi: PluginApi = BbbPluginSdk.getPluginApi(uuid);
+
+  const { data: pluginSettings, loading: isPluginSettingsLoading } = pluginApi.usePluginSettings();
+
+  useEffect(() => {
+    if (!isPluginSettingsLoading
+      && pluginSettings
+      && pluginSettings.pingSoundEnabled) {
+      Notification.requestPermission();
+    }
+  }, [isPluginSettingsLoading, pluginSettings]);
+
   const currentUserInfo = pluginApi.useCurrentUser();
   const { data: currentUser } = currentUserInfo;
   const allUsersInfo = pluginApi
@@ -128,6 +140,8 @@ function PickRandomUserPlugin({ pluginUuid: uuid }: PickRandomUserPluginProps) {
     <>
       <PickUserModal
         {...{
+          pluginSettings,
+          isPluginSettingsLoading,
           showModal,
           handleCloseModal,
           users: usersToBePicked?.user,


### PR DESCRIPTION
### What does this PR do?

It adds a ping sound and a notification for whenever a user is randomly picked 

This new feature can be configurable as I see some might feel uncomfortable with undesired sound coming from the computer (And by default is not enabled).

To enable it one must add the following config to their `/etc/bigbluebutton/bbb-html5.yml` in `public.plugins`:

```yaml
- name: PickRandomUserPlugin
      settings:
        pingSoundEnabled: true
        pingSoundUrl: resources/sounds/doorbell.mp3
```

So it would result in:

```yaml
public:
  # ...
  plugins:
    - name: PickRandomUserPlugin 
      settings:
        pingSoundEnabled: true
        pingSoundUrl: resources/sounds/doorbell.mp3
```

### Motivation

Some users have complained about not knowing when they were randomly picked by this plugin, because their tab was not opened or focused. This should resolve their issue. 

### More

See some demo below with another `pingSoundUrl` just as an example (Turn the volume up so that you can properly hear the ping sound):

https://github.com/user-attachments/assets/bb3efcfc-dd53-4744-a851-52c752465f84

The one used for this example is `resources/sounds/alarm.mp3` but feel free to try the others out and even try the default (by not specifying anything).
