### PR TITLE
feat: Add hardcoded fallback to each locale message

### DIFF
--- a/src/components/extensible-areas/action-button-dropdown/component.tsx
+++ b/src/components/extensible-areas/action-button-dropdown/component.tsx
@@ -9,10 +9,12 @@ const intlMessages = defineMessages({
   pickUserLabel: {
     id: 'pickRandomUserPlugin.actionsButtonDropdown.label.pickUser',
     description: 'Title to show that current user has been picked',
+    defaultMessage: 'Pick random user',
   },
   viewLastPickedUserLabel: {
     id: 'pickRandomUserPlugin.actionsButtonDropdown.label.viewLastPickedUser',
     description: 'Label of the actions button dropdown option to display the last picked user',
+    defaultMessage: 'Display last randomly picked user',
   },
 });
 

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -11,6 +11,7 @@ const intlMessages = defineMessages({
   currentUserPicked: {
     id: 'pickRandomUserPlugin.modal.pickedUserView.title.currentUserPicked',
     description: 'Title to show that current user has been picked',
+    defaultMessage: 'You have been randomly picked',
   },
 });
 

--- a/src/components/modal/picked-user-view/component.tsx
+++ b/src/components/modal/picked-user-view/component.tsx
@@ -9,18 +9,22 @@ const intlMessages = defineMessages({
   currentUserPicked: {
     id: 'pickRandomUserPlugin.modal.pickedUserView.title.currentUserPicked',
     description: 'Title to show that current user has been picked',
+    defaultMessage: 'You have been randomly picked',
   },
   randomUserPicked: {
     id: 'pickRandomUserPlugin.modal.pickedUserView.title.randomUserPicked',
     description: 'Title to show that random user has been picked',
+    defaultMessage: 'Randomly picked user',
   },
   backButtonLabel: {
     id: 'pickRandomUserPlugin.modal.pickedUserView.backButton.label',
     description: 'Label of back button in picked-user view on the modal',
+    defaultMessage: 'back',
   },
   avatarImageAlternativeText: {
     id: 'pickRandomUserPlugin.modal.pickedUserView.avatarImage.alternativeText',
     description: 'Alternative text for avatar image',
+    defaultMessage: 'Avatar image of user {0}',
   },
 });
 

--- a/src/components/modal/presenter-view/component.tsx
+++ b/src/components/modal/presenter-view/component.tsx
@@ -11,58 +11,72 @@ const intlMessages = defineMessages({
   optionsTitle: {
     id: 'pickRandomUserPlugin.modal.presenterView.optionSection.title',
     description: 'Title of the options section on modal`s presenter view',
+    defaultMessage: 'Options',
   },
   skipModeratorsLabel: {
     id: 'pickRandomUserPlugin.modal.presenterView.optionSection.skipModeratorsLabel',
     description: 'Label of skip moderator`s option on modal`s presenter view',
+    defaultMessage: 'Skip moderators',
   },
   skipPresenterLabel: {
     id: 'pickRandomUserPlugin.modal.presenterView.optionSection.skipPresenterLabel',
     description: 'Label of skip presenter`s option on modal`s presenter view',
+    defaultMessage: 'Skip presenter',
   },
   includePickedUsersLabel: {
     id: 'pickRandomUserPlugin.modal.presenterView.optionSection.includePickedUsersLabel',
     description: 'Label of include picked users option on modal`s presenter view',
+    defaultMessage: 'Include already picked user',
   },
   availableTitle: {
     id: 'pickRandomUserPlugin.modal.presenterView.availableSection.title',
     description: 'Title of the "available users" section on modal`s presenter view',
+    defaultMessage: 'Available for selection',
   },
   userLabel: {
     id: 'pickRandomUserPlugin.modal.presenterView.availableSection.userLabel',
     description: 'Label to count user in "available users" section on presenter view',
+    defaultMessage: 'user',
   },
   userLabelPlural: {
     id: 'pickRandomUserPlugin.modal.presenterView.availableSection.userLabelPlural',
     description: 'Label to count users in "available users" section on presenter view',
+    defaultMessage: 'users',
   },
   viewerLabel: {
     id: 'pickRandomUserPlugin.modal.presenterView.availableSection.viewerLabel',
     description: 'Label to count viewer in "available users" section on presenter view',
+    defaultMessage: 'viewer',
   },
   viewerLabelPlural: {
     id: 'pickRandomUserPlugin.modal.presenterView.availableSection.viewerLabelPlural',
     description: 'Label to count viewers in "available users" section on presenter view',
+    defaultMessage: 'viewers',
   },
   previouslyPickedTitle: {
     id: 'pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.title',
     description: 'Title of the "previously picked" section on presenter view',
+    defaultMessage: 'Previously picked',
   },
   clearButtonLabel: {
     id: 'pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.clearButtonLabel',
     description: 'Label of button to clear list of already picked users',
+    defaultMessage: 'Clear All',
   },
   noUsersWarning: {
     id: 'pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.noUsersWarning',
     description: 'Warning that there is no user to be picked',
+    defaultMessage: 'No {0} available to randomly pick from',
   },
   pickButtonLabel: {
     id: 'pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.pickButtonLabel.pickUser',
     description: 'Label of the button to pick another user',
+    defaultMessage: 'Pick {0}',
   },
   pickAgainButtonLabel: {
     id: 'pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.pickButtonLabel.pickAgain',
     description: 'Label of the button to pick another user',
+    defaultMessage: 'Pick again',
   },
 });
 


### PR DESCRIPTION
### What does this PR do?

This PR adds new hardcoded messages as a fallback for when the correct message is not even in the `en.json` locales.

The code might be a little bit duplicated because we have the same message in 2 places (as the default messages are the same as those in `en.json`), but from a user perspective, this will help a bunch, as it will avoid displaying the key of the locale message if there was a fail when fetching `en.json`, for instance. 

### More

During this PR, a bug was found in `useLocaleMessages`, which is: if the `en.json` file is empty, the change of language doesn't work, this might be happening when merging the fallback messages with the desired messages.
- [ ] Fix problem when `en.json` is empty
