### PR TITLE
Use predictable order to list available users

### DIFF
--- a/src/components/pick-random-user/component.tsx
+++ b/src/components/pick-random-user/component.tsx
@@ -112,6 +112,8 @@ function PickRandomUserPlugin({ pluginUuid: uuid }: PickRandomUserPluginProps) {
     }).filter((user) => {
       if (filterOutPresenter) return !user.presenter;
       return true;
+    }).sort((userA, userB) => {
+      return userA?.name.localeCompare(userB?.name);
     }),
   };
 


### PR DESCRIPTION
### What does this PR do?

The list of available users is now sorted by name, resulting on the fixed order if the user list doesn't change.

The previous implementation resulted in a flickering user list, that should be fixed with this issue.

### Closes Issue(s)

Closes #57 