### PR TITLE
fix: Don't notify when current user changes presenter. 

### DIFF
--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -6,6 +6,7 @@ import * as Styled from './styles';
 import { PickUserModalProps, WindowClientSettings } from './types';
 import { PickedUserViewComponent } from './picked-user-view/component';
 import { PresenterViewComponent } from './presenter-view/component';
+import hasCurrentUserSeenPickedUser from '../../utils/utils';
 
 const intlMessages = defineMessages({
   currentUserPicked: {
@@ -64,9 +65,17 @@ export function PickUserModal(props: PickUserModalProps) {
 
   useEffect(() => {
     // Play audio when user is selected
+
+    const hasCurrentUserSeen = hasCurrentUserSeenPickedUser(
+      pickedUserSeenEntries,
+      userId,
+      pickedUserWithEntryId?.pickedUser?.userId,
+    );
     const isPingSoundEnabled = !isPluginSettingsLoading && pluginSettings?.pingSoundEnabled;
     if (isPingSoundEnabled && pickedUserWithEntryId
-      && pickedUserWithEntryId?.pickedUser?.userId === userId) {
+      && pickedUserWithEntryId?.pickedUser?.userId === userId
+      // Current user must not have seen this entry and data should be done loading
+      && !hasCurrentUserSeen && !pickedUserSeenEntries?.loading) {
       const { cdn, basename } = window.meetingClientSettings.public.app;
       const host = cdn + basename;
       const pingSoundUrl: string = pluginSettings?.pingSoundUrl
@@ -76,7 +85,7 @@ export function PickUserModal(props: PickUserModalProps) {
       audio.play();
       notifyRandomlyPickedUser(intl.formatMessage(intlMessages.currentUserPicked));
     }
-  }, [userId, pickedUserWithEntryId]);
+  }, [userId, pickedUserWithEntryId, pickedUserSeenEntries]);
 
   useEffect(() => {
     setShowPresenterView(currentUser?.presenter && !pickedUserWithEntryId);

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -60,12 +60,13 @@ export function PickUserModal(props: PickUserModalProps) {
     currentUser?.presenter && !pickedUserWithEntryId,
   );
 
+  const [userId, setUserId] = useState(currentUser?.userId || '');
+
   useEffect(() => {
-    setShowPresenterView(currentUser?.presenter && !pickedUserWithEntryId);
     // Play audio when user is selected
     const isPingSoundEnabled = !isPluginSettingsLoading && pluginSettings?.pingSoundEnabled;
     if (isPingSoundEnabled && pickedUserWithEntryId
-      && pickedUserWithEntryId?.pickedUser?.userId === currentUser?.userId) {
+      && pickedUserWithEntryId?.pickedUser?.userId === userId) {
       const { cdn, basename } = window.meetingClientSettings.public.app;
       const host = cdn + basename;
       const pingSoundUrl: string = pluginSettings?.pingSoundUrl
@@ -74,6 +75,13 @@ export function PickUserModal(props: PickUserModalProps) {
       const audio = new Audio(pingSoundUrl);
       audio.play();
       notifyRandomlyPickedUser(intl.formatMessage(intlMessages.currentUserPicked));
+    }
+  }, [userId, pickedUserWithEntryId]);
+
+  useEffect(() => {
+    setShowPresenterView(currentUser?.presenter && !pickedUserWithEntryId);
+    if (userId === '') {
+      setUserId(currentUser.userId);
     }
   }, [currentUser, pickedUserWithEntryId]);
   return (

--- a/src/components/modal/picked-user-view/styles.tsx
+++ b/src/components/modal/picked-user-view/styles.tsx
@@ -70,5 +70,5 @@ export {
   PickedUserAvatarInitials,
   PickedUserAvatarImage,
   PickedUserName,
-  BackButton
+  BackButton,
 };


### PR DESCRIPTION
### What does this PR do?

It fixes an issue found a few weeks back, the issue is described below:
- The current user (a presenter) is randomly selected;
- The current user is notified;
- The presenter changes to another user in the session;
- The current user is notified again despite not being selected.

### More

See demo down below:

https://github.com/user-attachments/assets/9f571b0a-99b5-41b7-b17e-3efe6acb0b9c



