### PR TITLE
fix: rename main branch to v0.0.x in build workflow

### DIFF
--- a/.github/workflows/build-plugin-deb-package.yml
+++ b/.github/workflows/build-plugin-deb-package.yml
@@ -2,11 +2,11 @@
 name: "📦 Build .deb package for plugin"
 on:
   push:
-    branches: [ "main"]
+    branches: [ "v0.0.x"]
     paths-ignore:
       - debian/changelog
   pull_request:
-    branches: [ "main" ]
+    branches: [ "v0.0.x" ]
     paths-ignore:
       - debian/changelog
 


### PR DESCRIPTION
After doing away with the name 'main' I had not replaced it from some workflows