### PR TITLE
fix: Render modal in core container element with low priority

### DIFF
--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -46,9 +46,14 @@ export function PickUserModal(props: PickUserModalProps) {
   useEffect(() => {
     setShowPresenterView(currentUser?.presenter && !currentPickedUser);
   }, [currentUser, currentPickedUser]);
+
+  if (!showModal) return null;
+
   return (
     <Styled.PluginModal
       overlayClassName="modalOverlay"
+      portalClassName="modal-low"
+      parentSelector={() => document.querySelector('#modals-container')}
       isOpen={showModal}
       onRequestClose={handleCloseModal}
     >


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

This PR makes the modal be rendered inside the core modal container with low priority so that we can control its stacking order. Giving it low priority will hide it when both audio and video dialogs are open. This also fix an issue where the client get stuck at the pick-random-user modal when the audio dialog is open as well.

Without this fix:

[Screencast from 2025-09-04 10-40-19.webm](https://github.com/user-attachments/assets/67a8d179-fc3c-4035-990e-3900d0953bb6)

With this fix:

[Screencast from 2025-09-04 10-33-39.webm](https://github.com/user-attachments/assets/a177b309-ecdc-41ef-aeec-b4509d7a7348)


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes none but it's closely related to https://github.com/bigbluebutton/bigbluebutton/issues/23699.