### PR TITLE
fix: Previously picked user wrongfully notified in next random selections 

### DIFF
--- a/src/commons/hooks.ts
+++ b/src/commons/hooks.ts
@@ -1,4 +1,5 @@
 import { PluginApi } from 'bigbluebutton-html-plugin-sdk';
+import { useEffect, useRef } from 'react';
 import { createIntl, createIntlCache } from 'react-intl';
 
 const LOCALE_REQUEST_OBJECT = (!process.env.NODE_ENV || process.env.NODE_ENV === 'development')
@@ -26,4 +27,12 @@ export const useGetInternationalization = (pluginApi: PluginApi) => {
     intl,
     localeMessagesLoading,
   };
+};
+
+export const usePreviousValue = <T = unknown>(value: T) => {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
 };

--- a/src/components/modal/hooks.ts
+++ b/src/components/modal/hooks.ts
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { CurrentUserData, DataChannelEntryResponseType, GraphqlResponseWrapper } from 'bigbluebutton-html-plugin-sdk';
-import { hasCurrentUserSeenPickedUser } from '../../commons/utils';
 import { PickedUserSeenEntryDataChannel, PickedUserWithEntryId } from '../pick-random-user/types';
 import { PickRandomUserSettings } from '../../commons/types';
 import { notifyRandomlyPickedUser, pingSoundForRandomlyPickedUser } from './utils';
+import { usePreviousValue } from '../../commons/hooks';
+import { hasCurrentUserSeenPickedUser } from '../../commons/utils';
 
 const useCurrentUserId = (currentUser: CurrentUserData) => {
   const [currentUserId, setCurrentUserId] = useState(currentUser?.userId || '');
@@ -17,6 +18,57 @@ const useCurrentUserId = (currentUser: CurrentUserData) => {
   return currentUserId;
 };
 
+export const useRunWhenNeedNotification = (
+  notifyAndPingCallback: () => void,
+  currentUser: CurrentUserData,
+  pickedUserSeenEntries: GraphqlResponseWrapper<
+    DataChannelEntryResponseType<PickedUserSeenEntryDataChannel>[]>,
+  currentPickedUser: PickedUserWithEntryId,
+) => {
+  const currentUserId = useCurrentUserId(currentUser);
+
+  const [notificationRequestQueue, setNotificationRequestQueue] = useState<Set<string>>(new Set());
+
+  const previousPickedUserEntryId = usePreviousValue(currentPickedUser?.entryId);
+
+  const currentPickedUserId = currentPickedUser?.pickedUser?.userId;
+
+  useEffect(() => {
+    if (currentPickedUser
+      && currentPickedUserId === currentUserId
+      && previousPickedUserEntryId !== currentPickedUser.entryId
+    ) {
+      setNotificationRequestQueue((prevQueue) => {
+        const newQueue = new Set(prevQueue);
+        newQueue.add(currentPickedUser.entryId);
+        return newQueue;
+      });
+    }
+  }, [currentUserId, currentPickedUser]);
+
+  useEffect(() => {
+    Array.from(notificationRequestQueue).filter(
+      (notificationRequest) => notificationRequest === currentPickedUser?.entryId,
+    ).filter(() => {
+      const hasCurrentUserSeen = hasCurrentUserSeenPickedUser(
+        pickedUserSeenEntries,
+        currentUserId,
+        currentPickedUser?.pickedUser.userId,
+      );
+      return !hasCurrentUserSeen;
+    }).forEach((notificationRequest) => {
+      notifyAndPingCallback();
+      setNotificationRequestQueue((previousNotificationRequests) => {
+        const newQueue = new Set(previousNotificationRequests);
+        newQueue.delete(notificationRequest);
+        return newQueue;
+      });
+    });
+  }, [
+    notificationRequestQueue,
+  ]);
+};
+
 export const useHandleCurrentUserNotification = (
   currentUser: CurrentUserData,
   pickedUserSeenEntries: GraphqlResponseWrapper<
@@ -25,46 +77,21 @@ export const useHandleCurrentUserNotification = (
   pickRandomUserSettings: PickRandomUserSettings,
   notificationMessage: string,
 ) => {
-  const currentUserId = useCurrentUserId(currentUser);
-
   const { pingSoundEnabled, pingSoundUrl, browserNotificationEnabled } = pickRandomUserSettings;
 
-  const [currentUserNotified, setCurrentUserNotified] = useState(false);
-
-  const currentPickedUserId = currentPickedUser?.pickedUser?.userId;
-
-  // Control internal state of user-notification to not rely only on data-channel information
-  useEffect(() => {
-    const hasCurrentUserSeen = hasCurrentUserSeenPickedUser(
-      pickedUserSeenEntries,
-      currentUserId,
-      currentPickedUserId,
-    );
-    if (hasCurrentUserSeen) {
-      setCurrentUserNotified(false);
+  function notifyAndPing() {
+    if (pingSoundEnabled) pingSoundForRandomlyPickedUser(pingSoundUrl);
+    if (browserNotificationEnabled) {
+      notifyRandomlyPickedUser(
+        notificationMessage,
+      );
     }
-  }, [pickedUserSeenEntries]);
+  }
 
-  // Notify or ping audio (or both) when user is selected
-  useEffect(() => {
-    const hasCurrentUserSeen = hasCurrentUserSeenPickedUser(
-      pickedUserSeenEntries,
-      currentUserId,
-      currentPickedUserId,
-    );
-    if (currentPickedUser
-      && currentPickedUserId === currentUserId
-      // Current user must not have seen this entry and data should be done loading
-      && !hasCurrentUserSeen && !pickedUserSeenEntries?.loading
-      && !currentUserNotified
-    ) {
-      if (pingSoundEnabled) pingSoundForRandomlyPickedUser(pingSoundUrl);
-      if (browserNotificationEnabled) {
-        notifyRandomlyPickedUser(
-          notificationMessage,
-        );
-      }
-      setCurrentUserNotified(true);
-    }
-  }, [currentUserId, currentPickedUser, pickedUserSeenEntries, pickRandomUserSettings]);
+  useRunWhenNeedNotification(
+    notifyAndPing,
+    currentUser,
+    pickedUserSeenEntries,
+    currentPickedUser,
+  );
 };

--- a/src/components/modal/hooks.ts
+++ b/src/components/modal/hooks.ts
@@ -18,7 +18,7 @@ const useCurrentUserId = (currentUser: CurrentUserData) => {
   return currentUserId;
 };
 
-export const useRunWhenNeedNotification = (
+export const useObserveForNotification = (
   notifyAndPingCallback: () => void,
   currentUser: CurrentUserData,
   pickedUserSeenEntries: GraphqlResponseWrapper<
@@ -27,7 +27,7 @@ export const useRunWhenNeedNotification = (
 ) => {
   const currentUserId = useCurrentUserId(currentUser);
 
-  const [notificationRequestQueue, setNotificationRequestQueue] = useState<Set<string>>(new Set());
+  const [shouldNotify, setShouldNotify] = useState(false);
 
   const previousPickedUserEntryId = usePreviousValue(currentPickedUser?.entryId);
 
@@ -38,34 +38,23 @@ export const useRunWhenNeedNotification = (
       && currentPickedUserId === currentUserId
       && previousPickedUserEntryId !== currentPickedUser.entryId
     ) {
-      setNotificationRequestQueue((prevQueue) => {
-        const newQueue = new Set(prevQueue);
-        newQueue.add(currentPickedUser.entryId);
-        return newQueue;
-      });
+      setShouldNotify(true);
     }
   }, [currentUserId, currentPickedUser]);
 
   useEffect(() => {
-    Array.from(notificationRequestQueue).filter(
-      (notificationRequest) => notificationRequest === currentPickedUser?.entryId,
-    ).filter(() => {
-      const hasCurrentUserSeen = hasCurrentUserSeenPickedUser(
-        pickedUserSeenEntries,
-        currentUserId,
-        currentPickedUser?.pickedUser.userId,
-      );
-      return !hasCurrentUserSeen;
-    }).forEach((notificationRequest) => {
+    const hasCurrentUserSeen = hasCurrentUserSeenPickedUser(
+      pickedUserSeenEntries,
+      currentUserId,
+      currentPickedUser?.pickedUser.userId,
+    );
+    const notifyUser = !pickedUserSeenEntries?.loading && !hasCurrentUserSeen && shouldNotify;
+    if (notifyUser) {
       notifyAndPingCallback();
-      setNotificationRequestQueue((previousNotificationRequests) => {
-        const newQueue = new Set(previousNotificationRequests);
-        newQueue.delete(notificationRequest);
-        return newQueue;
-      });
-    });
+    }
+    setShouldNotify(false);
   }, [
-    notificationRequestQueue,
+    shouldNotify,
   ]);
 };
 
@@ -88,7 +77,7 @@ export const useHandleCurrentUserNotification = (
     }
   }
 
-  useRunWhenNeedNotification(
+  useObserveForNotification(
     notifyAndPing,
     currentUser,
     pickedUserSeenEntries,


### PR DESCRIPTION
### What does this PR do?

It fixes a problem described ahead:

Suppose we have a meeting with a moderator (M), and 3 viewers (A, B and C):
- M runs pick-random-user which selects A, for instance;
- Ping sounds to A;
- M runs pick-random-user again which selects B, this time;
- Ping sounds for both A and B;
- So on...

This error does not occur everytime, but is sort of frequent;

### More

Most of the notification/ping flow was refactored in this PR to be, supposedly, cleaner, more readable and less complex. In order words, it would be good to test other scenarios as well to see if everything keeps working, such as not ping again when reloading the page, not ping multiple times, and so on...
