### PR TITLE
fix: added of modal lock countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Down below, we list all the possible configurations this plugin supports, and th
     pingSoundUrl: resources/sounds/doorbell.mp3
     browserNotificationEnabled: true
     pickedUserTimeWindow: 10 # seconds
+    preventCloseDelaySeconds: 3 # seconds
 ```
 
 | Name                   | Description                          | Default                     |
@@ -37,8 +38,32 @@ Down below, we list all the possible configurations this plugin supports, and th
 | `pingSoundEnabled`     | Flag that decides whether the ping sound is enabled for picked user    | `true`                      |
 | `pingSoundUrl`         | URL of the ping sound file           | `resources/sounds/doorbell.mp3` |
 | `browserNotificationEnabled` | Flag that decides whether to send browser notification when user is picked | `false` |
-| `pickedUserTimeWindow` | Time window to consider a user as recently picked (users that join after that time will not see the last modal) | `30`               |
+| `pickedUserTimeWindow` | Time window to consider a user as recently picked (users that join after that time will not see the last modal) | `10`               |
+| `preventCloseDelaySeconds` | Delay in seconds before the modal can be closed to prevent accidental closures | `3` |
 
+
+### Prevent Close Delay
+
+By default, when the modal appears showing the picked user (the view that displays the selected user's name and avatar), it cannot be closed for 3 seconds. This prevents accidental closures from misclicks. During this time:
+- The close button (X) is disabled and grayed out
+- Clicking outside the modal does nothing
+- Pressing the Escape key does nothing
+- Visual countdown indicator:
+  - **For viewers**: A text message below the user's name: "You can close this modal in X seconds"
+  - **For presenters**: A blue progress bar (similar to YouTube's) that shrinks as time passes
+
+**Note:** This delay only applies to the picked user view. The presenter view (used for selecting users) can be closed immediately without any delay.
+
+After the countdown finishes, all close methods become available. To change this delay, add the following settings in the `/etc/bigbluebutton/bbb-html5.yml` file:
+
+```yaml
+public:
+  # ...
+  plugins:
+    - name: PickRandomUserPlugin
+      settings:
+        preventCloseDelaySeconds: 5  # Set to 0 to disable the delay
+```
 
 ### Notification
 

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -18,5 +18,7 @@
   "pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.pickButtonLabel.pickUser": "Pick {0}",
   "pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.pickButtonLabel.pickAgain": "Pick again",
   "pickRandomUserPlugin.actionsButtonDropdown.label.pickUser": "Pick random user",
-  "pickRandomUserPlugin.actionsButtonDropdown.label.viewLastPickedUser": "Display last randomly picked user"
+  "pickRandomUserPlugin.actionsButtonDropdown.label.viewLastPickedUser": "Display last randomly picked user",
+  "pickRandomUserPlugin.modal.closeDelayMessage": "You can close this modal in {seconds} seconds",
+  "pickRandomUserPlugin.modal.closeDelayMessageSingular": "You can close this modal in {seconds} second"
 }

--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -3,3 +3,5 @@ export const PICKED_USER_TIME_WINDOW = 10; // seconds
 export const TIMEOUT_CLOSE_NOTIFICATION = 5000;
 
 export const DEFAULT_PING_SOUND_URL = 'resources/sounds/doorbell.mp3';
+
+export const DEFAULT_PREVENT_CLOSE_DELAY_SECONDS = 3; // seconds

--- a/src/commons/types.ts
+++ b/src/commons/types.ts
@@ -3,4 +3,5 @@ export interface PickRandomUserSettings {
   pingSoundUrl: string;
   browserNotificationEnabled: boolean;
   pickedUserTimeWindow: number;
+  preventCloseDelaySeconds: number;
 }

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -47,7 +47,7 @@ export function PickUserModal(props: PickUserModalProps) {
     setShowPresenterView(currentUser?.presenter && !currentPickedUser);
   }, [currentUser, currentPickedUser]);
 
-  const {remainingSeconds, canClose} = usePreventCloseModalCountdown(
+  const { remainingSeconds, canClose } = usePreventCloseModalCountdown(
     currentUser,
     pickedUserSeenEntries,
     currentPickedUser,

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -5,7 +5,7 @@ import * as Styled from './styles';
 import { PickUserModalProps } from './types';
 import { PickedUserViewComponent } from './picked-user-view/component';
 import { PresenterViewComponent } from './presenter-view/component';
-import { useHandleCurrentUserNotification } from './hooks';
+import { useHandleCurrentUserNotification, usePreventCloseModalCountdown } from './hooks';
 
 const intlMessages = defineMessages({
   currentUserPicked: {
@@ -47,7 +47,24 @@ export function PickUserModal(props: PickUserModalProps) {
     setShowPresenterView(currentUser?.presenter && !currentPickedUser);
   }, [currentUser, currentPickedUser]);
 
+  const {remainingSeconds, canClose} = usePreventCloseModalCountdown(
+    currentUser,
+    pickedUserSeenEntries,
+    currentPickedUser,
+    pickRandomUserSettings,
+  );
+
   if (!showModal) return null;
+
+  const handleCloseAttempt = () => {
+    if (canClose) {
+      handleCloseModal();
+    }
+  };
+
+  const progressPercentage = pickRandomUserSettings.preventCloseDelaySeconds > 0
+    ? (remainingSeconds / pickRandomUserSettings.preventCloseDelaySeconds) * 100
+    : 0;
 
   return (
     <Styled.PluginModal
@@ -55,15 +72,20 @@ export function PickUserModal(props: PickUserModalProps) {
       portalClassName="modal-low"
       parentSelector={() => document.querySelector('#modals-container')}
       isOpen={showModal}
-      onRequestClose={handleCloseModal}
+      onRequestClose={handleCloseAttempt}
+      shouldCloseOnOverlayClick={canClose}
+      shouldCloseOnEsc={canClose}
     >
       <Styled.CloseButtonWrapper>
         <Styled.CloseButton
           type="button"
-          onClick={() => {
-            handleCloseModal();
-          }}
+          onClick={handleCloseAttempt}
           aria-label="Close button"
+          disabled={!canClose}
+          style={{
+            opacity: canClose ? 1 : 0.5,
+            cursor: canClose ? 'pointer' : 'not-allowed',
+          }}
         >
           <i
             className="icon-bbb-close"
@@ -93,6 +115,9 @@ export function PickUserModal(props: PickUserModalProps) {
                 currentUser,
                 showModal,
                 setShowPresenterView,
+                remainingSeconds,
+                canClose,
+                progressPercentage,
               }}
             />
           )

--- a/src/components/modal/hooks.ts
+++ b/src/components/modal/hooks.ts
@@ -1,10 +1,15 @@
-import { useEffect, useState } from 'react';
+import {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
 import { CurrentUserData, DataChannelEntryResponseType, GraphqlResponseWrapper } from 'bigbluebutton-html-plugin-sdk';
 import { PickedUserSeenEntryDataChannel, PickedUserWithEntryId } from '../pick-random-user/types';
 import { PickRandomUserSettings } from '../../commons/types';
 import { notifyRandomlyPickedUser, pingSoundForRandomlyPickedUser } from './utils';
 import { usePreviousValue } from '../../commons/hooks';
 import { hasCurrentUserSeenPickedUser } from '../../commons/utils';
+
+const UPDATE_COUNTDOWN_RATE = 100; // milliseconds
+const COUNTDOWN_RATE_IN_SECONDS = UPDATE_COUNTDOWN_RATE / 1000;
 
 const useCurrentUserId = (currentUser: CurrentUserData) => {
   const [currentUserId, setCurrentUserId] = useState(currentUser?.userId || '');
@@ -83,4 +88,70 @@ export const useHandleCurrentUserNotification = (
     pickedUserSeenEntries,
     currentPickedUser,
   );
+};
+
+export const usePreventCloseModalCountdown = (
+  currentUser: CurrentUserData,
+  pickedUserSeenEntries: GraphqlResponseWrapper<
+    DataChannelEntryResponseType<PickedUserSeenEntryDataChannel>[]>,
+  currentPickedUser: PickedUserWithEntryId,
+  pickRandomUserSettings: PickRandomUserSettings,
+) => {
+  const { preventCloseDelaySeconds } = pickRandomUserSettings;
+
+  const [remainingSeconds, setRemainingSeconds] = useState<number>(preventCloseDelaySeconds);
+  const [canClose, setCanClose] = useState<boolean>(true);
+  const intervalInstanceRef = useRef<NodeJS.Timeout | null>(null);
+
+  const currentUserSeenPickedUser: boolean = useMemo(
+    () => hasCurrentUserSeenPickedUser(
+      pickedUserSeenEntries,
+      currentUser.userId,
+      currentPickedUser?.pickedUser.userId,
+    ),
+    [pickedUserSeenEntries, currentPickedUser, preventCloseDelaySeconds],
+  );
+
+  const stopCountdown = (interval: NodeJS.Timeout) => {
+    intervalInstanceRef.current = null;
+    clearInterval(interval);
+    setCanClose(true);
+  };
+
+  const handleCountdownTick = (interval: NodeJS.Timeout) => {
+    setRemainingSeconds((prev) => {
+      const newValue = prev - COUNTDOWN_RATE_IN_SECONDS;
+      if (newValue >= 0) {
+        return newValue;
+      }
+      stopCountdown(interval);
+      return 0;
+    });
+  };
+
+  const startCountdown = () => {
+    setCanClose(false);
+    const interval = setInterval(() => {
+      handleCountdownTick(interval);
+    }, UPDATE_COUNTDOWN_RATE);
+    intervalInstanceRef.current = interval;
+  };
+
+  const resetCountdown = () => {
+    setRemainingSeconds(preventCloseDelaySeconds);
+    if (intervalInstanceRef.current) {
+      clearInterval(intervalInstanceRef.current);
+    }
+    if (preventCloseDelaySeconds > 0) {
+      startCountdown();
+    }
+  };
+
+  useEffect(() => {
+    if (!currentUserSeenPickedUser && currentPickedUser) {
+      resetCountdown();
+    } else if (!currentPickedUser) stopCountdown(intervalInstanceRef.current);
+  }, [currentUserSeenPickedUser, currentPickedUser]);
+
+  return { remainingSeconds, canClose };
 };

--- a/src/components/modal/picked-user-view/component.tsx
+++ b/src/components/modal/picked-user-view/component.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { defineMessages } from 'react-intl';
 import { PickedUserViewComponentProps } from './types';
 import * as Styled from './styles';
@@ -38,7 +38,6 @@ const intlMessages = defineMessages({
   },
 });
 
-
 export function PickedUserViewComponent(props: PickedUserViewComponentProps) {
   const {
     intl,
@@ -51,8 +50,6 @@ export function PickedUserViewComponent(props: PickedUserViewComponentProps) {
     canClose,
     progressPercentage,
   } = props;
-
-  
 
   const handleBackToPresenterView = () => {
     if (currentUser?.presenter) {

--- a/src/components/modal/picked-user-view/component.tsx
+++ b/src/components/modal/picked-user-view/component.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { defineMessages } from 'react-intl';
 import { PickedUserViewComponentProps } from './types';
 import * as Styled from './styles';
@@ -26,7 +26,18 @@ const intlMessages = defineMessages({
     description: 'Alternative text for avatar image',
     defaultMessage: 'Avatar image of user {0}',
   },
+  modalCloseDelayMessage: {
+    id: 'pickRandomUserPlugin.modal.closeDelayMessage',
+    description: 'Message showing countdown before modal can be closed',
+    defaultMessage: 'You can close this modal in {seconds} seconds',
+  },
+  modalCloseDelayMessageSingular: {
+    id: 'pickRandomUserPlugin.modal.closeDelayMessageSingular',
+    description: 'Message showing countdown before modal can be closed (singular)',
+    defaultMessage: 'You can close this modal in {seconds} second',
+  },
 });
+
 
 export function PickedUserViewComponent(props: PickedUserViewComponentProps) {
   const {
@@ -36,7 +47,12 @@ export function PickedUserViewComponent(props: PickedUserViewComponentProps) {
     setShowPresenterView,
     pickedUserSeenEntries,
     pushPickedUserSeen,
+    remainingSeconds,
+    canClose,
+    progressPercentage,
   } = props;
+
+  
 
   const handleBackToPresenterView = () => {
     if (currentUser?.presenter) {
@@ -65,6 +81,7 @@ export function PickedUserViewComponent(props: PickedUserViewComponentProps) {
   const avatarAltDescriptor = intl.formatMessage(intlMessages.currentUserPicked, {
     0: pickedUserWithEntryId?.pickedUser?.name,
   });
+
   return (
     <Styled.PickedUserViewWrapper>
       <Styled.PickedUserViewTitle>{title}</Styled.PickedUserViewTitle>
@@ -87,6 +104,16 @@ export function PickedUserViewComponent(props: PickedUserViewComponentProps) {
           </>
         ) : null
       }
+      {!canClose && remainingSeconds > 0 && !currentUser?.presenter && (
+        <Styled.CountdownMessage>
+          {intl.formatMessage(
+            remainingSeconds === 1
+              ? intlMessages.modalCloseDelayMessageSingular
+              : intlMessages.modalCloseDelayMessage,
+            { seconds: Math.ceil(remainingSeconds) },
+          )}
+        </Styled.CountdownMessage>
+      )}
       {
         (currentUser?.presenter) ? (
           <Styled.BackButton type="button" onClick={handleBackToPresenterView}>
@@ -94,6 +121,11 @@ export function PickedUserViewComponent(props: PickedUserViewComponentProps) {
           </Styled.BackButton>
         ) : null
       }
+      {!canClose && remainingSeconds > 0 && currentUser?.presenter && (
+        <Styled.CountdownBarContainer>
+          <Styled.CountdownBar progress={progressPercentage} />
+        </Styled.CountdownBarContainer>
+      )}
     </Styled.PickedUserViewWrapper>
   );
 }

--- a/src/components/modal/picked-user-view/styles.tsx
+++ b/src/components/modal/picked-user-view/styles.tsx
@@ -64,6 +64,36 @@ const BackButton = styled.button`
   }
 `;
 
+const CountdownMessage = styled.div`
+  width: 100%;
+  text-align: center;
+  padding: 0.75rem 1rem;
+  margin-top: 1rem;
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+  color: #6c757d;
+  font-size: 0.9rem;
+  font-weight: 500;
+`;
+
+const CountdownBarContainer = styled.div`
+  width: 100%;
+  height: 4px;
+  background-color: #e9ecef;
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 1rem;
+`;
+
+const CountdownBar = styled.div<{ progress: number }>`
+  height: 100%;
+  background: linear-gradient(90deg, #0F70D7 0%, #0C57A7 100%);
+  width: ${({ progress }) => progress}%;
+  transition: width linear 0.1s;
+  border-radius: 2px;
+`;
+
 export {
   PickedUserViewWrapper,
   PickedUserViewTitle,
@@ -71,4 +101,7 @@ export {
   PickedUserAvatarImage,
   PickedUserName,
   BackButton,
+  CountdownMessage,
+  CountdownBarContainer,
+  CountdownBar,
 };

--- a/src/components/modal/picked-user-view/types.ts
+++ b/src/components/modal/picked-user-view/types.ts
@@ -15,6 +15,9 @@ export interface PickedUserViewComponentProps {
         DataChannelEntryResponseType<PickedUserSeenEntryDataChannel>[]>;
     pushPickedUserSeen: PushEntryFunction<PickedUserSeenEntryDataChannel>;
     setShowPresenterView: React.Dispatch<React.SetStateAction<boolean>>;
+    remainingSeconds: number;
+    canClose: boolean;
+    progressPercentage: number;
 }
 
 export interface ModalAvatarProps {

--- a/src/components/modal/styles.tsx
+++ b/src/components/modal/styles.tsx
@@ -76,7 +76,22 @@ const CloseButtonWrapper = styled.div`
   width: 100%;
   align-items: flex-end;
   display: flex;
-  flex-direction: column; 
+  flex-direction: column;
 `;
 
-export { PluginModal, CloseButton, CloseButtonWrapper };
+const CountdownMessage = styled.div`
+  width: 100%;
+  text-align: center;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+  color: #6c757d;
+  font-size: 0.9rem;
+  font-weight: 500;
+`;
+
+export {
+  PluginModal, CloseButton, CloseButtonWrapper, CountdownMessage,
+};

--- a/src/components/pick-random-user/hooks.ts
+++ b/src/components/pick-random-user/hooks.ts
@@ -8,7 +8,11 @@ import {
 } from 'bigbluebutton-html-plugin-sdk';
 import { PluginSettingsData } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-consumption/domain/settings/plugin-settings/types';
 import { useEffect, useState } from 'react';
-import { DEFAULT_PING_SOUND_URL, PICKED_USER_TIME_WINDOW } from '../../commons/constants';
+import {
+  DEFAULT_PING_SOUND_URL,
+  DEFAULT_PREVENT_CLOSE_DELAY_SECONDS,
+  PICKED_USER_TIME_WINDOW,
+} from '../../commons/constants';
 import { hasCurrentUserSeenPickedUser, isNumber } from '../../commons/utils';
 import { PickRandomUserSettings } from '../../commons/types';
 import { WindowClientSettings } from '../modal/types';
@@ -81,13 +85,26 @@ const getPingSoundUrl = (settings: PluginSettingsData): string => {
   return pingSoundUrl;
 };
 
+const getPreventCloseDelayFromSettings = (settings: PluginSettingsData) => {
+  const settingPreventCloseDelay = settings.preventCloseDelaySeconds as unknown;
+  if (isNumber(settingPreventCloseDelay)) {
+    const delay: number = settingPreventCloseDelay as number;
+    return delay;
+  } return DEFAULT_PREVENT_CLOSE_DELAY_SECONDS;
+};
+
 export const useGetAllSettings = (
   settingsData: GraphqlResponseWrapper<PluginSettingsData>,
 ): PickRandomUserSettings => {
   const [pingSoundEnabled, setPingSoundEnabled] = useState<boolean>(true);
   const [browserNotificationEnabled, setBrowserNotificationEnabled] = useState<boolean>(false);
   const [pingSoundUrl, setPingSoundUrl] = useState<string>(DEFAULT_PING_SOUND_URL);
-  const [pickedUserTimeWindow, setPickedUserTimeWindow] = useState<number>(PICKED_USER_TIME_WINDOW);
+  const [pickedUserTimeWindow, setPickedUserTimeWindow] = useState<number>(
+    PICKED_USER_TIME_WINDOW,
+  );
+  const [preventCloseDelaySeconds, setPreventCloseDelaySeconds] = useState<number>(
+    DEFAULT_PREVENT_CLOSE_DELAY_SECONDS,
+  );
   useSettingsLoaded((settings) => {
     setBrowserNotificationEnabled(
       (previousState) => getBrowserNotificationEnabled(settings, previousState),
@@ -97,12 +114,14 @@ export const useGetAllSettings = (
     );
     setPickedUserTimeWindow(getPickedUserTimeWindowFromSettings(settings));
     setPingSoundUrl(getPingSoundUrl(settings));
+    setPreventCloseDelaySeconds(getPreventCloseDelayFromSettings(settings));
   }, settingsData);
   return {
     pingSoundEnabled,
     pingSoundUrl,
     browserNotificationEnabled,
     pickedUserTimeWindow,
+    preventCloseDelaySeconds,
   };
 };
 


### PR DESCRIPTION
### What does this PR do?

This PR implements an optional delay before the picked user modal can be closed, preventing accidental dismissals from misclicks. The changes include:

- **Configuration System**: Added `preventCloseDelaySeconds` setting (default: 3 seconds) to control modal close delay
- **Countdown Logic**: Implemented timer that prevents closing via close button, overlay click, or Escape key during countdown
- **Visual Indicators**:
  - **For Viewers**: Text message displaying "You can close this modal in X seconds"
  - **For Presenters**: Smooth blue progress bar at the bottom of the modal that shrinks over time

### Closes Issue(s)

Closes #59 

### Motivation

When a user is randomly picked, the modal appears to notify participants. However, users can accidentally close this important notification with a misclick before seeing who was selected. This feature adds a configurable delay to ensure users have time to acknowledge the selection, improving the overall user experience and reducing confusion in meetings.

### More

- [x] Added/updated documentation (README.md)
- [x] Added internationalization support (en.json)

**Configuration Example:**
```yaml
public:
  plugins:
    - name: PickRandomUserPlugin
      settings:
        preventCloseDelaySeconds: 3  # Set to 0 to disable
```

See demo (I set the delay to be of 10 seconds via configuration, but the default is 3):

https://github.com/user-attachments/assets/cc2d5e6f-9782-4a5a-9a19-a7174366a4ab


