### PR TITLE
feat: Filter out users with bot flag 

### DIFF
--- a/src/components/pick-random-user/queries.ts
+++ b/src/components/pick-random-user/queries.ts
@@ -1,12 +1,14 @@
+// TODO: Replace this query with the useUsersBasicInfo once it's merged in
 export const USERS_MORE_INFORMATION = `
 subscription usersMoreInformation {
-  user {
+  user(where: { bot: { _eq: false } }) {
     color
     name
     userId
     role
     presenter
     avatar
+    bot
   }
 }
 `;

--- a/src/components/pick-random-user/types.ts
+++ b/src/components/pick-random-user/types.ts
@@ -5,6 +5,7 @@ export interface PickedUser {
     role: string;
     avatar: string;
     color: string;
+    bot: boolean;
 }
 
 export interface PickedUserWithEntryId {

--- a/src/components/pick-random-user/utils.ts
+++ b/src/components/pick-random-user/utils.ts
@@ -11,7 +11,7 @@ export const filterPossibleUsersToBePicked = (
   pickedUserFromDataChannel: DataChannelEntryResponseType<PickedUser>[],
   filterOptions: FilterOptionsType,
 ) => ({
-  user: allUsers?.user.filter((user) => {
+  user: allUsers?.user.filter((user) => !user.bot).filter((user) => {
     if (!filterOptions.includeModerators) return user.role === Role.VIEWER;
     return true;
   }).filter((user) => {


### PR DESCRIPTION
### What does this PR do?

This PR implements a filter to remove bots.

### Closes Issue(s)

Closes #79

### More

One thing to keep in mind:

- In this PR, I added a filter to the subscription to exclude users flagged as bots.
- Additionally, I added a filter in the TypeScript logic when selecting the user to be randomly picked.

The reason for this is that we are planning to change the subscription used to retrieve all users. At the moment, we rely on a custom subscription that isn’t reused anywhere else. The idea is that once this PR is merged — https://github.com/bigbluebutton/bigbluebutton/pull/24213 — we will have all the necessary information to switch to the proper CORE hook (useUsersBasicInfo). This will allow us to reuse the subscription and improve overall performance.

---
Se demo below:

https://github.com/user-attachments/assets/5aee852c-2e10-416d-8019-ca09b218bbd1





