### PR TITLE
Add missing labels for includeModeratorsLabel and includePresenterLabel - fixes #70

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -4,6 +4,8 @@
   "pickRandomUserPlugin.modal.pickedUserView.backButton.label": "zurück",
   "pickRandomUserPlugin.modal.pickedUserView.avatarImage.alternativeText": "Avatar von Teilnehmer {0}",
   "pickRandomUserPlugin.modal.presenterView.optionSection.title": "Optionen",
+  "pickRandomUserPlugin.modal.presenterView.optionSection.includeModeratorsLabel": "Moderatoren einbeziehen",
+  "pickRandomUserPlugin.modal.presenterView.optionSection.includePresenterLabel": "Präsentator einbeziehen",
   "pickRandomUserPlugin.modal.presenterView.optionSection.includePickedUsersLabel": "Wähle bereits gewählte Teilnehmer",
   "pickRandomUserPlugin.modal.presenterView.availableSection.title": "Zur Auswahl stehen",
   "pickRandomUserPlugin.modal.presenterView.availableSection.userLabel": "Teilnehmer",

--- a/public/locales/fr-FR.json
+++ b/public/locales/fr-FR.json
@@ -3,6 +3,8 @@
   "pickRandomUserPlugin.modal.pickedUserView.title.randomUserPicked": "Participant sélectionné au hasard",
   "pickRandomUserPlugin.modal.pickedUserView.backButton.label": "retour",
   "pickRandomUserPlugin.modal.presenterView.optionSection.title": "Options",
+  "pickRandomUserPlugin.modal.presenterView.optionSection.includeModeratorsLabel": "Inclure les modérateurs",
+  "pickRandomUserPlugin.modal.presenterView.optionSection.includePresenterLabel": "Inclure le présentateur",
   "pickRandomUserPlugin.modal.presenterView.optionSection.includePickedUsersLabel": "Inclure un participant déjà sélectionné",
   "pickRandomUserPlugin.modal.presenterView.availableSection.title": "Disponible pour la sélection",
   "pickRandomUserPlugin.modal.presenterView.availableSection.userLabel": "participant",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -3,6 +3,8 @@
   "pickRandomUserPlugin.modal.pickedUserView.title.randomUserPicked": "Utente scelto a caso",
   "pickRandomUserPlugin.modal.pickedUserView.backButton.label": "indietro",
   "pickRandomUserPlugin.modal.presenterView.optionSection.title": "Opzioni",
+  "pickRandomUserPlugin.modal.presenterView.optionSection.includeModeratorsLabel": "Includi moderatori",
+  "pickRandomUserPlugin.modal.presenterView.optionSection.includePresenterLabel": "Includi il presentatore",
   "pickRandomUserPlugin.modal.presenterView.optionSection.includePickedUsersLabel": "Includi l'utente già selezionato",
   "pickRandomUserPlugin.modal.presenterView.availableSection.title": "Disponibile per la selezione",
   "pickRandomUserPlugin.modal.presenterView.availableSection.userLabel": "utente",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -4,6 +4,8 @@
   "pickRandomUserPlugin.modal.pickedUserView.backButton.label": "戻る",
   "pickRandomUserPlugin.modal.pickedUserView.avatarImage.alternativeText": "ユーザー {0} のアバター画像",
   "pickRandomUserPlugin.modal.presenterView.optionSection.title": "設定",
+  "pickRandomUserPlugin.modal.presenterView.optionSection.includeModeratorsLabel": "モデレーターを含める",
+  "pickRandomUserPlugin.modal.presenterView.optionSection.includePresenterLabel": "発表者を含める",
   "pickRandomUserPlugin.modal.presenterView.optionSection.includePickedUsersLabel": "既に指名した人を含める",
   "pickRandomUserPlugin.modal.presenterView.availableSection.title": "指名可能な人",
   "pickRandomUserPlugin.modal.presenterView.availableSection.userLabel": "人のユーザー",

--- a/public/locales/pt-BR.json
+++ b/public/locales/pt-BR.json
@@ -4,6 +4,8 @@
   "pickRandomUserPlugin.modal.pickedUserView.backButton.label": "voltar",
   "pickRandomUserPlugin.modal.pickedUserView.avatarImage.alternativeText": "Iamgem avatar do usuário {0}",
   "pickRandomUserPlugin.modal.presenterView.optionSection.title": "Opções",
+  "pickRandomUserPlugin.modal.presenterView.optionSection.includeModeratorsLabel": "Incluir moderadores",
+  "pickRandomUserPlugin.modal.presenterView.optionSection.includePresenterLabel": "Incluir apresentador",
   "pickRandomUserPlugin.modal.presenterView.optionSection.includePickedUsersLabel": "Incluir usuário já selecionado",
   "pickRandomUserPlugin.modal.presenterView.availableSection.title": "Disponíveis para seleção",
   "pickRandomUserPlugin.modal.presenterView.availableSection.userLabel": "usuário",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Adds missing labels in non-EN localization json files for includeModeratorsLabel and includePresenterLabel.

### Closes Issue(s)
Closes #70

### Motivation
Entries missing in de.json, fr-FR.json, it.json, ja.json and pt-BR.json.