### PR TITLE
Feat: Enable close button in the "can't-close" state 

### DIFF
--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -59,8 +59,8 @@ export function PickUserModal(props: PickUserModalProps) {
 
   if (!showModal) return null;
 
-  const handleCloseAttempt = () => {
-    if (canClose) {
+  const handleCloseAttempt = (isFromCloseButton: boolean = false) => {
+    if (canClose || isFromCloseButton) {
       handleCloseModal();
     }
   };
@@ -83,13 +83,8 @@ export function PickUserModal(props: PickUserModalProps) {
       <Styled.CloseButtonWrapper>
         <Styled.CloseButton
           type="button"
-          onClick={handleCloseAttempt}
+          onClick={() => handleCloseAttempt(true)}
           aria-label="Close button"
-          disabled={!canClose}
-          style={{
-            opacity: canClose ? 1 : 0.5,
-            cursor: canClose ? 'pointer' : 'not-allowed',
-          }}
         >
           <i
             className="icon-bbb-close"

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -59,8 +59,8 @@ export function PickUserModal(props: PickUserModalProps) {
 
   if (!showModal) return null;
 
-  const handleCloseAttempt = (isFromCloseButton: boolean = false) => {
-    if (canClose || isFromCloseButton) {
+  const handleCloseAttempt = () => {
+    if (canClose) {
       handleCloseModal();
     }
   };
@@ -83,7 +83,7 @@ export function PickUserModal(props: PickUserModalProps) {
       <Styled.CloseButtonWrapper>
         <Styled.CloseButton
           type="button"
-          onClick={() => handleCloseAttempt(true)}
+          onClick={handleCloseModal}
           aria-label="Close button"
         >
           <i


### PR DESCRIPTION
### What does this PR do?

Re-enables the close button when the modal is in the can't-close state.

### Motivation

The can't-close behavior was originally implemented to prevent the modal from closing when a user accidentally clicks outside of it after a new selection.

However, blocking the close button is unnecessary. If a user clicks the close button, it is very likely intentional given the small and precise click area.