### PR TITLE
ref: Change modal lock countdown from 3 seconds to 1 second

### DIFF
--- a/src/commons/constants.ts
+++ b/src/commons/constants.ts
@@ -4,4 +4,4 @@ export const TIMEOUT_CLOSE_NOTIFICATION = 5000;
 
 export const DEFAULT_PING_SOUND_URL = 'resources/sounds/doorbell.mp3';
 
-export const DEFAULT_PREVENT_CLOSE_DELAY_SECONDS = 3; // seconds
+export const DEFAULT_PREVENT_CLOSE_DELAY_SECONDS = 1; // seconds


### PR DESCRIPTION
### What does this PR do?

Decrease picked user modal lock time to 1 second (previous 3 seconds).

### Motivation

Due to lots of user complains on the amount of active lock time for the picked user modal, we reduced the default to 1 second, hoping this will still prevent accidental closing click, and also not harm user experience
