### PR TITLE
fix: "0 users available for selection" when there is a valid selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -172,7 +172,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -182,7 +181,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -255,7 +253,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.29.7",
@@ -365,7 +362,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.29.7",
@@ -487,7 +483,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -512,7 +507,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.29.7",
@@ -2804,7 +2798,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -3291,6 +3284,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -4663,7 +4675,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -5033,7 +5044,6 @@
       "version": "2.10.17",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
       "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
-      "dev": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
@@ -5197,7 +5207,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5318,7 +5327,6 @@
       "version": "1.0.30001787",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
       "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5648,7 +5656,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -6146,7 +6153,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6256,8 +6262,7 @@
     "node_modules/electron-to-chromium": {
       "version": "1.5.334",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
-      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
-      "dev": true
+      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -6568,7 +6573,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7702,7 +7706,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -7916,6 +7919,15 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
@@ -9196,7 +9208,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -9536,7 +9547,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -9861,8 +9871,7 @@
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "dev": true
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -10906,7 +10915,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -10936,7 +10944,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -10980,6 +10987,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "peer": true
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -11522,7 +11535,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -11608,7 +11620,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13084,7 +13095,7 @@
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -13188,7 +13199,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14141,7 +14151,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -28,6 +28,7 @@
   "pickRandomUserPlugin.modal.title": "Zufälligen Teilnehmer wählen",
   "pickRandomUserPlugin.modal.closeButton.ariaLabel": "Schließen",
   "pickRandomUserPlugin.modal.presenterView.availableSection.emptyState": "Keine {0} zur Auswahl verfügbar",
+  "pickRandomUserPlugin.modal.presenterView.availableSection.loading": "Wird geladen…",
   "pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.emptyState": "Noch kein Teilnehmer ausgewählt",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.moderator": "Moderator",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.presenter": "Präsentator",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -28,6 +28,7 @@
   "pickRandomUserPlugin.modal.title": "Pick random user",
   "pickRandomUserPlugin.modal.closeButton.ariaLabel": "Close",
   "pickRandomUserPlugin.modal.presenterView.availableSection.emptyState": "No {0} available for selection",
+  "pickRandomUserPlugin.modal.presenterView.availableSection.loading": "Loading…",
   "pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.emptyState": "No user selected yet",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.moderator": "moderator",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.presenter": "presenter",

--- a/public/locales/fr-FR.json
+++ b/public/locales/fr-FR.json
@@ -27,6 +27,7 @@
   "pickRandomUserPlugin.modal.title": "Sélectionner un participant au hasard",
   "pickRandomUserPlugin.modal.closeButton.ariaLabel": "Fermer",
   "pickRandomUserPlugin.modal.presenterView.availableSection.emptyState": "Aucun {0} disponible pour la sélection",
+  "pickRandomUserPlugin.modal.presenterView.availableSection.loading": "Chargement…",
   "pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.emptyState": "Aucun participant sélectionné pour l'instant",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.moderator": "modérateur",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.presenter": "présentateur",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -27,6 +27,7 @@
   "pickRandomUserPlugin.modal.title": "Scegli un utente casuale",
   "pickRandomUserPlugin.modal.closeButton.ariaLabel": "Chiudi",
   "pickRandomUserPlugin.modal.presenterView.availableSection.emptyState": "Nessun {0} disponibile per la selezione",
+  "pickRandomUserPlugin.modal.presenterView.availableSection.loading": "Caricamento…",
   "pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.emptyState": "Nessun utente selezionato ancora",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.moderator": "moderatore",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.presenter": "presentatore",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -28,6 +28,7 @@
   "pickRandomUserPlugin.modal.title": "ランダムにユーザーを選択",
   "pickRandomUserPlugin.modal.closeButton.ariaLabel": "閉じる",
   "pickRandomUserPlugin.modal.presenterView.availableSection.emptyState": "選択可能な{0}はいません",
+  "pickRandomUserPlugin.modal.presenterView.availableSection.loading": "読み込み中…",
   "pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.emptyState": "まだユーザーが選択されていません",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.moderator": "モデレーター",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.presenter": "発表者",

--- a/public/locales/pt-BR.json
+++ b/public/locales/pt-BR.json
@@ -28,6 +28,7 @@
   "pickRandomUserPlugin.modal.title": "Selecionar usuário aleatório",
   "pickRandomUserPlugin.modal.closeButton.ariaLabel": "Fechar",
   "pickRandomUserPlugin.modal.presenterView.availableSection.emptyState": "Nenhum {0} disponível para seleção",
+  "pickRandomUserPlugin.modal.presenterView.availableSection.loading": "Carregando…",
   "pickRandomUserPlugin.modal.presenterView.previouslyPickedSection.emptyState": "Nenhum usuário selecionado ainda",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.moderator": "moderador",
   "pickRandomUserPlugin.modal.presenterView.roleLabel.presenter": "apresentador",

--- a/src/components/modal/component.tsx
+++ b/src/components/modal/component.tsx
@@ -2,13 +2,23 @@ import {
   useCallback, useEffect, useRef, useState,
 } from 'react';
 import * as React from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, IntlShape } from 'react-intl';
+import {
+  CurrentUserData,
+  DataChannelEntryResponseType,
+  DeleteEntryFunction,
+  GraphqlResponseWrapper,
+  PluginApi,
+  PushEntryFunction,
+} from 'bigbluebutton-html-plugin-sdk';
 import * as Styled from './styles';
-import { PickUserModalProps } from './types';
+import { FilterOptionsType, PickUserModalProps } from './types';
 import { PickedUserViewComponent } from './picked-user-view/component';
 import { PresenterViewComponent } from './presenter-view/component';
+import { useGetPossibleUsersToBePicked } from './presenter-view/hooks';
 import { useGetFilterOptions, useHandleCurrentUserNotification, usePreventCloseModalCountdown } from './hooks';
 import { MIN_PREVENT_CLOSE_DELAY_FOR_TOAST_SECONDS } from '../../commons/constants';
+import { PickedUser, PickedUserWithEntryId, PickedUserSeenEntryDataChannel } from '../pick-random-user/types';
 
 const intlMessages = defineMessages({
   currentUserPicked: {
@@ -42,6 +52,88 @@ const intlMessages = defineMessages({
     defaultMessage: 'You can close this modal in {ms}ms',
   },
 });
+
+interface PresenterModalContentProps {
+  showPresenterView: boolean;
+  pluginApi: PluginApi;
+  filterOptions: FilterOptionsType;
+  setFilterOptions: React.Dispatch<React.SetStateAction<FilterOptionsType>>;
+  deletionFunction: DeleteEntryFunction;
+  dataChannelPickedUsers: DataChannelEntryResponseType<PickedUser>[] | undefined;
+  pickedUserWithEntryId: PickedUserWithEntryId | null;
+  intl: IntlShape;
+  currentUser: CurrentUserData;
+  pickedUserSeenEntries: GraphqlResponseWrapper<
+    DataChannelEntryResponseType<PickedUserSeenEntryDataChannel>[]>;
+  pushPickedUserSeen: PushEntryFunction<PickedUserSeenEntryDataChannel>;
+  setShowPresenterView: React.Dispatch<React.SetStateAction<boolean>>;
+  remainingSeconds: number;
+  canClose: boolean;
+}
+
+// Kept mounted for as long as the presenter has the modal open, regardless of whether
+// they are looking at the presenter view or the just-picked-user view. This keeps the
+// useUsersBasicInfo subscription (and its loading state) alive across picks instead of
+// tearing it down and recreating it every time the presenter picks someone, which used
+// to cause the "Available for selection" list to flash back into a loading state on
+// every pick. The subscription still dies normally when the modal closes or the
+// component stops rendering (e.g. the user is no longer the presenter).
+function PresenterModalContent(props: PresenterModalContentProps) {
+  const {
+    showPresenterView,
+    pluginApi,
+    filterOptions,
+    setFilterOptions,
+    deletionFunction,
+    dataChannelPickedUsers,
+    pickedUserWithEntryId,
+    intl,
+    currentUser,
+    pickedUserSeenEntries,
+    pushPickedUserSeen,
+    setShowPresenterView,
+    remainingSeconds,
+    canClose,
+  } = props;
+
+  const { users: usersToBePicked, isLoading } = useGetPossibleUsersToBePicked(
+    pluginApi,
+    filterOptions,
+  );
+
+  if (showPresenterView) {
+    return (
+      <PresenterViewComponent
+        {...{
+          intl,
+          filterOptions,
+          setFilterOptions,
+          deletionFunction,
+          dataChannelPickedUsers,
+          pluginApi,
+          pickedUserWithEntryId,
+          usersToBePicked,
+          isLoading,
+        }}
+      />
+    );
+  }
+
+  return (
+    <PickedUserViewComponent
+      {...{
+        pickedUserSeenEntries,
+        pushPickedUserSeen,
+        pickedUserWithEntryId,
+        intl,
+        currentUser,
+        setShowPresenterView,
+        remainingSeconds,
+        canClose,
+      }}
+    />
+  );
+}
 
 function OverlayWithToast({
   overlayProps,
@@ -216,17 +308,24 @@ export function PickUserModal(props: PickUserModalProps) {
         </Styled.CloseButton>
       </Styled.ModalHeader>
       {
-        showPresenterView
+        isPresenter
           ? (
-            <PresenterViewComponent
+            <PresenterModalContent
               {...{
-                intl,
+                showPresenterView,
+                pluginApi,
                 filterOptions,
                 setFilterOptions,
                 deletionFunction,
                 dataChannelPickedUsers,
-                pluginApi,
                 pickedUserWithEntryId: currentPickedUser,
+                intl,
+                currentUser,
+                pickedUserSeenEntries,
+                pushPickedUserSeen,
+                setShowPresenterView,
+                remainingSeconds,
+                canClose,
               }}
             />
           ) : (

--- a/src/components/modal/presenter-view/component.tsx
+++ b/src/components/modal/presenter-view/component.tsx
@@ -7,7 +7,7 @@ import * as Styled from './styles';
 import { PickedUser } from '../../pick-random-user/types';
 import { PresenterViewComponentProps } from './types';
 import { UserAvatar } from '../user-avatar/component';
-import { useGetPickRandomUserFunction, useGetPossibleUsersToBePicked } from './hooks';
+import { useGetPickRandomUserFunction } from './hooks';
 import { formatPickedTime } from './utils';
 
 const intlMessages = defineMessages({
@@ -164,6 +164,8 @@ export function PresenterViewComponent(props: PresenterViewComponentProps) {
     pluginApi,
     filterOptions,
     setFilterOptions,
+    usersToBePicked,
+    isLoading,
   } = props;
 
   const {
@@ -171,11 +173,6 @@ export function PresenterViewComponent(props: PresenterViewComponentProps) {
     includePresenter,
     includePickedUsers,
   } = filterOptions;
-
-  const { users: usersToBePicked, isLoading } = useGetPossibleUsersToBePicked(
-    pluginApi,
-    filterOptions,
-  );
 
   const handlePickRandomUser = useGetPickRandomUserFunction(pluginApi, usersToBePicked);
 

--- a/src/components/modal/presenter-view/component.tsx
+++ b/src/components/modal/presenter-view/component.tsx
@@ -96,6 +96,11 @@ const intlMessages = defineMessages({
     description: 'Empty state text shown when no user is available for selection',
     defaultMessage: 'No {0} available for selection',
   },
+  availableLoading: {
+    id: 'pickRandomUserPlugin.modal.presenterView.availableSection.loading',
+    description: 'Loading text shown while the list of users is still being fetched',
+    defaultMessage: 'Loading…',
+  },
   moderatorRoleLabel: {
     id: 'pickRandomUserPlugin.modal.presenterView.roleLabel.moderator',
     description: 'Role badge label for moderators',
@@ -167,7 +172,10 @@ export function PresenterViewComponent(props: PresenterViewComponentProps) {
     includePickedUsers,
   } = filterOptions;
 
-  const usersToBePicked = useGetPossibleUsersToBePicked(pluginApi, filterOptions);
+  const { users: usersToBePicked, isLoading } = useGetPossibleUsersToBePicked(
+    pluginApi,
+    filterOptions,
+  );
 
   const handlePickRandomUser = useGetPickRandomUserFunction(pluginApi, usersToBePicked);
 
@@ -262,13 +270,22 @@ export function PresenterViewComponent(props: PresenterViewComponentProps) {
               {userRoleLabel}
             </Styled.CountBadge>
           </Styled.SectionHeaderRow>
-          {usersCount === 0 ? (
+          {isLoading && (
+            <Styled.LoadingContainer data-test="pickRandomUserAvailableLoading">
+              <Styled.SpinnerRing />
+              <Styled.LoadingText>
+                {intl.formatMessage(intlMessages.availableLoading)}
+              </Styled.LoadingText>
+            </Styled.LoadingContainer>
+          )}
+          {!isLoading && usersCount === 0 && (
             <Styled.EmptyStateContainer>
               <Styled.EmptyStateText>
                 {intl.formatMessage(intlMessages.availableEmptyState, { 0: userRoleLabel })}
               </Styled.EmptyStateText>
             </Styled.EmptyStateContainer>
-          ) : (
+          )}
+          {!isLoading && usersCount > 0 && (
             <Styled.UserListContainer>
               {usersToBePicked?.map((user) => {
                 let roleBadgeLabel: string | null = null;
@@ -328,7 +345,12 @@ export function PresenterViewComponent(props: PresenterViewComponentProps) {
 
       {/* FOOTER */}
       <Styled.FooterContainer>
-        {usersCount > 0 ? (
+        {isLoading && (
+          <Styled.NoUsersWarning data-test="pickRandomUserLoadingWarning">
+            {intl.formatMessage(intlMessages.availableLoading)}
+          </Styled.NoUsersWarning>
+        )}
+        {!isLoading && usersCount > 0 && (
           <Styled.PickButton
             type="button"
             data-test="pickRandomUserPickButton"
@@ -340,7 +362,8 @@ export function PresenterViewComponent(props: PresenterViewComponentProps) {
                 : intlMessages.pickAnotherRandomUserButtonLabel)
               : intl.formatMessage(intlMessages.pickButtonLabel)}
           </Styled.PickButton>
-        ) : (
+        )}
+        {!isLoading && usersCount === 0 && (
           <Styled.NoUsersWarning data-test="pickRandomUserNoUsersWarning">
             {intl.formatMessage(intlMessages.noUsersWarning, { 0: userRoleLabel })}
           </Styled.NoUsersWarning>

--- a/src/components/modal/presenter-view/hooks.ts
+++ b/src/components/modal/presenter-view/hooks.ts
@@ -49,7 +49,14 @@ export function useGetPossibleUsersToBePicked(
   const allUsersInfo = pluginApi?.useUsersBasicInfo
     ? pluginApi?.useUsersBasicInfo()
     : { data: undefined as undefined, loading: false, error: undefined };
-  const { data: allUsers } = allUsersInfo;
+  const { data: allUsers, loading } = allUsersInfo;
+
+  // This plugin relies on *live* data: the presenter must never pick someone who has
+  // already left. So we deliberately do NOT retain the previous snapshot — while the
+  // SDK is (re)fetching or has no data yet, we report loading instead of a possibly
+  // stale list. The footer hides the Pick button whenever isLoading is true, so the
+  // presenter cannot act on data we are not sure is current.
+  const isLoading = loading || allUsers === undefined;
 
   // TEMPORARY DEBUG INSTRUMENTATION — investigating an "unstable connection empties
   // the available-users list" report. Remove once diagnosed.
@@ -97,5 +104,5 @@ export function useGetPossibleUsersToBePicked(
     }, '[DEBUG pick-random-user] usersToBePicked recomputed');
   }, [result, filterOptions]);
 
-  return result;
+  return { users: result, isLoading };
 }

--- a/src/components/modal/presenter-view/hooks.ts
+++ b/src/components/modal/presenter-view/hooks.ts
@@ -1,7 +1,9 @@
+import { useEffect } from 'react';
 import {
   PluginApi,
   RESET_DATA_CHANNEL,
   UsersBasicInfoData,
+  pluginLogger,
 } from 'bigbluebutton-html-plugin-sdk';
 import {
   FilterOptionsType,
@@ -46,17 +48,54 @@ export function useGetPossibleUsersToBePicked(
 ) {
   const allUsersInfo = pluginApi?.useUsersBasicInfo
     ? pluginApi?.useUsersBasicInfo()
-    : { data: undefined as undefined };
+    : { data: undefined as undefined, loading: false, error: undefined };
   const { data: allUsers } = allUsersInfo;
+
+  // TEMPORARY DEBUG INSTRUMENTATION — investigating an "unstable connection empties
+  // the available-users list" report. Remove once diagnosed.
+  useEffect(() => {
+    pluginLogger.debug({
+      logCode: 'pick_random_user_debug_users_basic_info',
+      extraInfo: {
+        timestamp: new Date().toISOString(),
+        loading: allUsersInfo.loading,
+        hasError: !!allUsersInfo.error,
+        userCount: allUsers?.user?.length,
+        users: allUsers?.user?.map((u) => ({
+          userId: u.userId,
+          name: u.name,
+          role: u.role,
+          isModerator: u.isModerator,
+          presenter: u.presenter,
+          bot: u.bot,
+        })),
+      },
+    }, '[DEBUG pick-random-user] useUsersBasicInfo update');
+  }, [allUsersInfo]);
 
   const {
     data: pickedUserFromDataChannelResponse,
   } = pluginApi.useDataChannel<PickedUser>('pickRandomUser');
   const pickedUserFromDataChannel = pickedUserFromDataChannelResponse?.data || [];
 
-  return filterPossibleUsersToBePicked(
+  const result = filterPossibleUsersToBePicked(
     allUsers,
     pickedUserFromDataChannel,
     filterOptions,
   ).user;
+
+  // TEMPORARY DEBUG INSTRUMENTATION — see above.
+  useEffect(() => {
+    pluginLogger.debug({
+      logCode: 'pick_random_user_debug_filtered_result',
+      extraInfo: {
+        timestamp: new Date().toISOString(),
+        resultCount: result.length,
+        resultUserIds: result.map((u) => u.userId),
+        filterOptions,
+      },
+    }, '[DEBUG pick-random-user] usersToBePicked recomputed');
+  }, [result, filterOptions]);
+
+  return result;
 }

--- a/src/components/modal/presenter-view/styles.tsx
+++ b/src/components/modal/presenter-view/styles.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 // ── Section labels ────────────────────────────────────────────────────────────
 
@@ -160,6 +160,38 @@ const EmptyStateText = styled.span`
   color: #A7B3C3;
 `;
 
+// ── Loading state (shown while the first user snapshot has not arrived yet) ────
+
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`;
+
+const LoadingContainer = styled.div`
+  background: #F7F9FB;
+  border-radius: 0.375rem;
+  padding: 0.875rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+`;
+
+const SpinnerRing = styled.span`
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 2px solid #D1D9E3;
+  border-top-color: #4E7FF8;
+  animation: ${spin} 0.7s linear infinite;
+  flex-shrink: 0;
+`;
+
+const LoadingText = styled.span`
+  font-size: 0.8125rem;
+  color: #A7B3C3;
+`;
+
 const PickedUserListContainer = styled(UserListContainer)`
 `;
 
@@ -258,6 +290,9 @@ export {
   ClearAllButton,
   EmptyStateContainer,
   EmptyStateText,
+  LoadingContainer,
+  SpinnerRing,
+  LoadingText,
   PickedUserListContainer,
   PickedList,
   PickedUserRow,

--- a/src/components/modal/presenter-view/types.ts
+++ b/src/components/modal/presenter-view/types.ts
@@ -1,5 +1,7 @@
 import { DataChannelEntryResponseType } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-channel/types';
-import { DeleteEntryFunction, PluginApi } from 'bigbluebutton-html-plugin-sdk';
+import {
+  DeleteEntryFunction, PluginApi, UsersBasicInfoData,
+} from 'bigbluebutton-html-plugin-sdk';
 import { IntlShape } from 'react-intl';
 import { PickedUser, PickedUserWithEntryId } from '../../pick-random-user/types';
 import { FilterOptionsType } from '../types';
@@ -12,4 +14,6 @@ export interface PresenterViewComponentProps {
     pluginApi: PluginApi;
     filterOptions: FilterOptionsType;
     setFilterOptions: React.Dispatch<React.SetStateAction<FilterOptionsType>>;
+    usersToBePicked: UsersBasicInfoData[];
+    isLoading: boolean;
 }

--- a/tests/unit/presenter-subscription-lifecycle.test.tsx
+++ b/tests/unit/presenter-subscription-lifecycle.test.tsx
@@ -1,0 +1,210 @@
+import * as React from 'react';
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import { render } from '@testing-library/react';
+import { createIntl } from 'react-intl';
+import { PickUserModal } from '../../src/components/modal/component';
+import { PickedUser, PickedUserWithEntryId } from '../../src/components/pick-random-user/types';
+
+// The component tree under test pulls in RESET_DATA_CHANNEL and pluginLogger (values)
+// from the SDK. Stub them so the debug instrumentation does not reach the real logging
+// pipeline; every other SDK import used here is type-only and is erased at build time.
+vi.mock('bigbluebutton-html-plugin-sdk', () => ({
+  RESET_DATA_CHANNEL: 'RESET_DATA_CHANNEL',
+  DataChannelTypes: { LATEST_ITEM: 'Hooks::DataChannel::LatestItem' },
+  pluginLogger: {
+    debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  },
+}));
+
+// `styles.tsx` wraps react-modal with styled-components (`styled(ReactModal)`), which
+// relies on a CJS/ESM interop shape that only holds up under the real webpack build,
+// not vitest's esbuild-based transform. This test is about the presenter/modal-open
+// subscription gating in component.tsx, not react-modal's portal behaviour, so replace
+// the styled wrappers with plain passthroughs that respect `isOpen`.
+vi.mock('../../src/components/modal/styles', () => ({
+  PluginModal: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) => (
+    isOpen ? <div data-test="mock-plugin-modal">{children}</div> : null
+  ),
+  ModalHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ModalTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CloseButton: ({ children, ...rest }: React.ComponentPropsWithoutRef<'button'>) => (
+    <button type="button" {...rest}>{children}</button>
+  ),
+  ModalWithToastWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  FloatingToast: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const intl = createIntl({ locale: 'en', messages: {} });
+
+const graphqlWrapper = <T, >(data: T) => ({ loading: false, data, error: undefined });
+
+const pickedUser = (userId: string): PickedUser => ({
+  userId, name: userId, role: 'MODERATOR', presenter: false, bot: false, avatar: '', color: '#000',
+});
+
+// A pluginApi whose useUsersBasicInfo reports every subscribe/unsubscribe through the
+// given spies, mirroring how a real GraphQL subscription hook ties its lifecycle to the
+// mount/unmount of whichever component calls it.
+function makePluginApi(onSubscribe: () => void, onUnsubscribe: () => void) {
+  return {
+    useUsersBasicInfo: () => {
+      React.useEffect(() => {
+        onSubscribe();
+        return () => onUnsubscribe();
+      }, []);
+      return graphqlWrapper({ user: [] });
+    },
+    useDataChannel: () => ({
+      data: graphqlWrapper([]),
+      pushEntry: vi.fn(),
+      deleteEntry: vi.fn(),
+    }),
+    useCurrentUser: () => ({ data: { userId: 'presenter-1', presenter: true } }),
+  } as never;
+}
+
+const baseModalProps = {
+  uuid: 'test-uuid',
+  intl,
+  pickRandomUserSettings: {
+    pingSoundEnabled: false,
+    pingSoundUrl: '',
+    browserNotificationEnabled: false,
+    pickedUserTimeWindow: 30,
+    preventCloseDelaySeconds: 0,
+  },
+  handleCloseModal: vi.fn(),
+  dataChannelPickedUsers: undefined,
+  deletionFunction: vi.fn(),
+  pickedUserSeenEntries: graphqlWrapper([]),
+  pushPickedUserSeen: vi.fn(),
+};
+
+describe('presenter-view data subscription lifecycle (unstable connection follow-up)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="modals-container"></div>';
+  });
+
+  it('never subscribes when the current user is not the presenter, even with the modal open', () => {
+    const onSubscribe = vi.fn();
+    const onUnsubscribe = vi.fn();
+
+    render(
+      <PickUserModal
+        {...baseModalProps}
+        pluginApi={makePluginApi(onSubscribe, onUnsubscribe)}
+        showModal
+        currentUser={{ userId: 'viewer-1', presenter: false } as never}
+        currentPickedUser={{
+          pickedUser: pickedUser('viewer-1'), entryId: 'entry-1',
+        } as PickedUserWithEntryId}
+      />,
+    );
+
+    expect(onSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('never subscribes for the presenter while the modal is closed', () => {
+    const onSubscribe = vi.fn();
+    const onUnsubscribe = vi.fn();
+
+    render(
+      <PickUserModal
+        {...baseModalProps}
+        pluginApi={makePluginApi(onSubscribe, onUnsubscribe)}
+        showModal={false}
+        currentUser={{ userId: 'presenter-1', presenter: true } as never}
+        currentPickedUser={null}
+      />,
+    );
+
+    expect(onSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('subscribes exactly once when the presenter has the modal open, and does not re-subscribe across a pick', () => {
+    const onSubscribe = vi.fn();
+    const onUnsubscribe = vi.fn();
+    const pluginApi = makePluginApi(onSubscribe, onUnsubscribe);
+    const currentUser = { userId: 'presenter-1', presenter: true } as never;
+
+    const { rerender } = render(
+      <PickUserModal
+        {...baseModalProps}
+        pluginApi={pluginApi}
+        showModal
+        currentUser={currentUser}
+        currentPickedUser={null}
+      />,
+    );
+
+    expect(onSubscribe).toHaveBeenCalledTimes(1);
+    expect(onUnsubscribe).not.toHaveBeenCalled();
+
+    // The presenter picks someone: the modal internally swaps from the presenter view to
+    // the picked-user view. Before the fix, this unmounted/remounted the component that
+    // owned the subscription, causing a fresh loading state on every pick.
+    rerender(
+      <PickUserModal
+        {...baseModalProps}
+        pluginApi={pluginApi}
+        showModal
+        currentUser={currentUser}
+        currentPickedUser={{
+          pickedUser: pickedUser('attendee-1'), entryId: 'entry-1',
+        } as PickedUserWithEntryId}
+      />,
+    );
+
+    expect(onSubscribe).toHaveBeenCalledTimes(1);
+    expect(onUnsubscribe).not.toHaveBeenCalled();
+
+    // Back to the presenter view (e.g. the presenter clicked "back" / picked again) -
+    // still the same, uninterrupted subscription.
+    rerender(
+      <PickUserModal
+        {...baseModalProps}
+        pluginApi={pluginApi}
+        showModal
+        currentUser={currentUser}
+        currentPickedUser={null}
+      />,
+    );
+
+    expect(onSubscribe).toHaveBeenCalledTimes(1);
+    expect(onUnsubscribe).not.toHaveBeenCalled();
+  });
+
+  it('tears the subscription down once the modal is closed', () => {
+    const onSubscribe = vi.fn();
+    const onUnsubscribe = vi.fn();
+    const pluginApi = makePluginApi(onSubscribe, onUnsubscribe);
+    const currentUser = { userId: 'presenter-1', presenter: true } as never;
+
+    const { rerender } = render(
+      <PickUserModal
+        {...baseModalProps}
+        pluginApi={pluginApi}
+        showModal
+        currentUser={currentUser}
+        currentPickedUser={null}
+      />,
+    );
+
+    expect(onSubscribe).toHaveBeenCalledTimes(1);
+    expect(onUnsubscribe).not.toHaveBeenCalled();
+
+    rerender(
+      <PickUserModal
+        {...baseModalProps}
+        pluginApi={pluginApi}
+        showModal={false}
+        currentUser={currentUser}
+        currentPickedUser={null}
+      />,
+    );
+
+    expect(onUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/use-get-possible-users-to-be-picked.test.ts
+++ b/tests/unit/use-get-possible-users-to-be-picked.test.ts
@@ -1,0 +1,98 @@
+import {
+  describe, it, expect, vi,
+} from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useGetPossibleUsersToBePicked } from '../../src/components/modal/presenter-view/hooks';
+import { FilterOptionsType } from '../../src/components/modal/types';
+
+// The hook imports RESET_DATA_CHANNEL and pluginLogger (a value) from the SDK.
+// Stub them so the debug instrumentation does not reach the real logging pipeline.
+vi.mock('bigbluebutton-html-plugin-sdk', () => ({
+  RESET_DATA_CHANNEL: 'RESET_DATA_CHANNEL',
+  pluginLogger: {
+    debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  },
+}));
+
+const mod = (userId: string) => ({
+  userId, name: userId, role: 'MODERATOR', presenter: false, bot: false,
+});
+
+const filters = (over: Partial<FilterOptionsType> = {}): FilterOptionsType => ({
+  includeModerators: true,
+  includePresenter: true,
+  includePickedUsers: true,
+  ...over,
+});
+
+// A minimal PluginApi whose useUsersBasicInfo returns the given wrapper and whose
+// pickRandomUser data-channel is empty.
+const makePluginApi = (usersInfo: unknown) => ({
+  useUsersBasicInfo: () => usersInfo,
+  useDataChannel: () => ({ data: undefined }),
+}) as never;
+
+const loadingWrapper = { loading: true, data: undefined, error: undefined };
+const loadedWrapper = (users: ReturnType<typeof mod>[]) => ({
+  loading: false, data: { user: users }, error: undefined,
+});
+
+describe('useGetPossibleUsersToBePicked (unstable connection)', () => {
+  it('reports loading — not an empty room — while the first snapshot has not arrived', () => {
+    const { result } = renderHook(
+      ({ api }) => useGetPossibleUsersToBePicked(api, filters()),
+      { initialProps: { api: makePluginApi(loadingWrapper) } },
+    );
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.users).toEqual([]);
+  });
+
+  it('exposes the users once an authoritative snapshot arrives', () => {
+    const { result } = renderHook(
+      ({ api }) => useGetPossibleUsersToBePicked(api, filters()),
+      { initialProps: { api: makePluginApi(loadedWrapper([mod('m1'), mod('m2')])) } },
+    );
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.users.map((u) => u.userId)).toEqual(['m1', 'm2']);
+  });
+
+  it('reports loading — never a stale list — during a mid-session reconnect', () => {
+    // This plugin must not offer a picked user who may have already left, so it does
+    // NOT retain the previous snapshot. A reconnect surfaces as loading, not stale data.
+    const { result, rerender } = renderHook(
+      ({ api }) => useGetPossibleUsersToBePicked(api, filters()),
+      { initialProps: { api: makePluginApi(loadedWrapper([mod('m1'), mod('m2')])) } },
+    );
+    expect(result.current.users).toHaveLength(2);
+
+    // Connection drops: the subscription re-fires with loading / undefined data.
+    rerender({ api: makePluginApi(loadingWrapper) });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.users).toEqual([]);
+  });
+
+  it('reports loading when the SDK is refetching even though data is still present', () => {
+    // loading: true with a populated snapshot must still gate the Pick button, since we
+    // cannot be sure the snapshot is current.
+    const { result } = renderHook(
+      ({ api }) => useGetPossibleUsersToBePicked(api, filters()),
+      {
+        initialProps: {
+          api: makePluginApi({
+            loading: true, data: { user: [mod('m1'), mod('m2')] }, error: undefined,
+          }),
+        },
+      },
+    );
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('treats a genuinely empty room (authoritative empty snapshot) as not-loading', () => {
+    const { result } = renderHook(
+      ({ api }) => useGetPossibleUsersToBePicked(api, filters()),
+      { initialProps: { api: makePluginApi(loadedWrapper([])) } },
+    );
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.users).toEqual([]);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Investigates and fixes a bug where the presenter's "available for selection" list can incorrectly show 0 users under unstable connections.

- Adds temporary debug logging around `useUsersBasicInfo` and the filtered result, to trace the real-time roster data through a reconnect (still present, not yet removed — this is an ongoing investigation, see `BUG_INVESTIGATION_UNSTABLE_CONNECTION.md`).
- Adds a proper loading state: while the roster subscription is loading or has no data yet, the presenter view now shows "Loading…" instead of collapsing straight to "no users available." This stops a mid-reconnect roster read from being indistinguishable from a genuinely empty room.
- Fixes a related UX issue found while testing the above: the roster subscription was being torn down and recreated every time the presenter picked a user (because the component that owned it unmounted on every pick), which re-triggered the loading flash on every single pick. The subscription is now hoisted to a boundary that stays mounted for as long as the presenter has the modal open, and only tears down when the modal actually closes or they stop being the presenter.
- Adds a unit test asserting the subscription is only ever created while the current user is the presenter and the modal is open, and that it is not recreated across a pick.

### Motivation

While investigating a report that, for unstable connections, the presenter's pick-random-user modal would show 0 available users — with "Moderators" and "Presenter" checked, no previous pick, and eligible moderators/presenter visibly present in the meeting — we found the plugin had no way to distinguish "the roster subscription hasn't delivered its first/latest snapshot yet" from "there really are zero eligible users." That gap is what the debug logs were added to trace, and the loading-state fix directly addresses it. Testing the fix surfaced a second, independent annoyance (the subscription resetting on every pick), which is fixed in the same PR since it's caused by the same subscription's mount/unmount lifecycle.
