### PR TITLE
test: Adjust the readiness signal to not be wb

### DIFF
--- a/tests/behavioral/helpers.ts
+++ b/tests/behavioral/helpers.ts
@@ -36,7 +36,7 @@ export async function clickToggleOnWithRetry(
  * a sidebar and stays open between tests, so this is idempotent.
  */
 export async function openPickRandomUserPanel(modPage: Page): Promise<void> {
-  await modPage.page.waitForSelector(e.whiteboard, { timeout: ELEMENT_WAIT_LONGER_TIME });
+  await modPage.waitUntilInMeeting();
 
   if (await modPage.page.locator(e.pickRandomUserPanel).isVisible()) return;
 

--- a/tests/behavioral/multi-user.spec.ts
+++ b/tests/behavioral/multi-user.spec.ts
@@ -29,11 +29,11 @@ const setPluginUrl = (url: string) => { pluginUrl = url; };
 const getPluginUrl = () => pluginUrl;
 
 /**
- * Wait for the attendee's page to finish loading the whiteboard.
+ * Wait for the attendee's client to finish loading.
  * This ensures the attendee is fully in the meeting before the presenter picks.
  */
 async function waitForAttendeeMeeting(attendeePage: Page): Promise<void> {
-  await attendeePage.page.waitForSelector(e.whiteboard, { timeout: ELEMENT_WAIT_LONGER_TIME });
+  await attendeePage.waitUntilInMeeting();
 }
 
 /**
@@ -99,6 +99,7 @@ test.describe('Pick Random User Plugin - Behavioural (multi-user)', () => {
     if (attendeePage.settings?.autoJoinAudioModal) {
       await attendeePage.closeAudioModal();
     }
+    await attendeePage.waitUntilInMeeting();
     await attendeeRawPage.addStyleTag({
       content: "body { font-family: 'Liberation Sans', Arial, sans-serif; }",
     });
@@ -338,6 +339,7 @@ test.describe('Pick Random User Plugin - Behavioural (countdown and close-preven
     if (attendeePage.settings?.autoJoinAudioModal) {
       await attendeePage.closeAudioModal();
     }
+    await attendeePage.waitUntilInMeeting();
     await attendeeRawPage.addStyleTag({
       content: "body { font-family: 'Liberation Sans', Arial, sans-serif; }",
     });

--- a/tests/core/sessionPage.ts
+++ b/tests/core/sessionPage.ts
@@ -83,6 +83,7 @@ export class SessionPage {
       this.settings = await generateSettingsData(this.page);
       const autoJoinAudioModal = this.settings?.autoJoinAudioModal;
       if (shouldCloseAudioModal && autoJoinAudioModal) await this.closeAudioModal();
+      await this.waitUntilInMeeting();
     }
     // overwrite for font used in CI
     await this.page.addStyleTag({
@@ -131,5 +132,23 @@ export class SessionPage {
   async closeAudioModal() {
     await this.hasElement(e.audioModal, 'should display the audio modal', ELEMENT_WAIT_EXTRA_LONG_TIME);
     await this.page.click(e.closeModal);
+  }
+
+  /**
+   * Wait until the in-session client is ready to be driven.
+   *
+   * Deliberately keyed on the apps gallery button rather than on the whiteboard: this
+   * plugin is reached through the apps gallery, and the button renders for moderators and
+   * viewers alike regardless of what the media area is showing. The whiteboard is a poor
+   * readiness signal here — a server that sets layout.hidePresentationOnJoin
+   * joins users with the presentation minimized,
+   * and the canvas is then not in the DOM at all, so waiting for it can only time out.
+   */
+  async waitUntilInMeeting(timeout = ELEMENT_WAIT_EXTRA_LONG_TIME) {
+    await this.hasElement(
+      e.appsGallerySidebarButton,
+      'should display the apps gallery button once the client is in the meeting',
+      timeout,
+    );
   }
 }

--- a/tests/structural/test.spec.ts
+++ b/tests/structural/test.spec.ts
@@ -76,7 +76,7 @@ test.describe('Pick Random User Plugin - Structural', () => {
   }
 
   test('should list "Pick random user" in the apps gallery for a presenter', async (): Promise<void> => {
-    await modPage.page.waitForSelector(e.whiteboard, { timeout: ELEMENT_WAIT_LONGER_TIME });
+    await modPage.waitUntilInMeeting();
     await modPage.page.click(e.appsGallerySidebarButton);
     await modPage.hasElement(
       e.pickRandomUserAppsGalleryItem,


### PR DESCRIPTION
The whiteboard is not always visible on start and
one of the main testing servers had it hidden by default causing test failures.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Changes what element we observe to be sure that the client has loaded
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
Tests were failing for me because I was testing against a server with layout - hidden presentation (grid mode).
Given that this may become prevalent, I decided to observe a more present element instead - the gallery spot.
<!-- What inspired you to submit this pull request? -->

